### PR TITLE
Feature/profile page and course selection

### DIFF
--- a/src/main/java/com/github/wsustudygroupapp/config/WebSocketConfig.java
+++ b/src/main/java/com/github/wsustudygroupapp/config/WebSocketConfig.java
@@ -21,17 +21,12 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        // TODO: enable a simple in-memory broker for /topic
-        //  registry.enableSimpleBroker("/topic")
-
-        // TODO: prefix for messages sent FROM the client TO the server
-        //  registry.setApplicationDestinationPrefixes("/app")
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
     }
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        // TODO: register the WebSocket endpoint the frontend connects to
-        //  registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS()
-        //  withSockJS() adds fallback support for browsers that don't support WebSockets
+        registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
     }
 }

--- a/src/main/java/com/github/wsustudygroupapp/controller/CourseController.java
+++ b/src/main/java/com/github/wsustudygroupapp/controller/CourseController.java
@@ -4,12 +4,14 @@ import com.github.wsustudygroupapp.dto.CourseEnrollRequest;
 import com.github.wsustudygroupapp.model.Course;
 import com.github.wsustudygroupapp.model.UserCourse;
 import com.github.wsustudygroupapp.service.CourseService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-// TODO: Maicheal — exposes course enrollment endpoints
+// DONE: Maicheal — exposes course enrollment endpoints
 // All routes here require a valid JWT token
 
 @RestController
@@ -22,42 +24,61 @@ public class CourseController {
         this.courseService = courseService;
     }
 
-    // TODO: call courseService.getAllCourses()
-    // TODO: return 200 with the full course list (used for the frontend dropdown)
+    // DONE: call courseService.getAllCourses()
+    // DONE: return 200 with the full course list (used for the frontend dropdown)
     @GetMapping
     public ResponseEntity<List<Course>> getAllCourses() {
-        return null;
+        return ResponseEntity.ok(courseService.getAllCourses());
     }
 
-    // TODO: extract the logged-in user's profile ID
-    // TODO: call courseService.getMyCourses(profileId)
-    // TODO: return 200 with the student's enrolled courses
+    // DONE: extract the logged-in user's profile ID
+    // DONE: call courseService.getMyCourses(profileId)
+    // DONE: return 200 with the student's enrolled courses
     @GetMapping("/my")
-    public ResponseEntity<List<UserCourse>> getMyCourses() {
-        return null;
+    public ResponseEntity<List<UserCourse>> getMyCourses(Authentication authentication) {
+        return ResponseEntity.ok(courseService.getMyCourses(authentication.getName()));
     }
 
-    // TODO: extract the logged-in user's profile ID
-    // TODO: call courseService.enroll(profileId, request)
-    // TODO: return 201
+    // DONE: extract the logged-in user's profile ID
+    // DONE: call courseService.enroll(profileId, request)
+    // DONE: return 201
     @PostMapping("/enroll")
-    public ResponseEntity<UserCourse> enroll(@RequestBody CourseEnrollRequest request) {
-        return null;
+    public ResponseEntity<UserCourse> enroll(Authentication authentication,
+                                              @RequestBody CourseEnrollRequest request) {
+        // 201 Created — a new enrollment record was added
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(courseService.enroll(authentication.getName(), request));
     }
 
-    // TODO: extract the logged-in user's profile ID
-    // TODO: call courseService.drop(userCourseId, profileId)
-    // TODO: return 204 No Content
+    // DONE: extract the logged-in user's profile ID
+    // DONE: call courseService.drop(userCourseId, profileId)
+    // DONE: return 204 No Content
     @DeleteMapping("/{userCourseId}")
-    public ResponseEntity<Void> drop(@PathVariable Long userCourseId) {
-        return null;
+    public ResponseEntity<Void> drop(Authentication authentication,
+                                      @PathVariable Long userCourseId) {
+        courseService.drop(userCourseId, authentication.getName());
+        // 204 No Content — successful deletion with no response body
+        return ResponseEntity.noContent().build();
     }
 
-    // TODO: extract the logged-in user's profile ID
-    // TODO: call courseService.getClassmates(userCourseId, profileId)
-    // TODO: return 200 with the list of classmates
+    // DONE: extract the logged-in user's profile ID
+    // DONE: call courseService.getClassmates(userCourseId, profileId)
+    // DONE: return 200 with the list of classmates
     @GetMapping("/{userCourseId}/classmates")
-    public ResponseEntity<List<UserCourse>> getClassmates(@PathVariable Long userCourseId) {
-        return null;
+    public ResponseEntity<List<UserCourse>> getClassmates(Authentication authentication,
+                                                           @PathVariable Long userCourseId) {
+        return ResponseEntity.ok(courseService.getClassmates(userCourseId, authentication.getName()));
+    }
+
+    // Search courses by keyword: GET /courses/search?q=biology
+    @GetMapping("/search")
+    public ResponseEntity<List<Course>> searchCourses(@RequestParam String q) {
+        return ResponseEntity.ok(courseService.searchCourses(q));
+    }
+
+    // Filter by department code: GET /courses/department/CAIS
+    @GetMapping("/department/{code}")
+    public ResponseEntity<List<Course>> getCoursesByDepartment(@PathVariable String code) {
+        return ResponseEntity.ok(courseService.getCoursesByDepartment(code));
     }
 }

--- a/src/main/java/com/github/wsustudygroupapp/controller/ProfileController.java
+++ b/src/main/java/com/github/wsustudygroupapp/controller/ProfileController.java
@@ -3,10 +3,12 @@ package com.github.wsustudygroupapp.controller;
 import com.github.wsustudygroupapp.dto.ProfileRequest;
 import com.github.wsustudygroupapp.model.Profile;
 import com.github.wsustudygroupapp.service.ProfileService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
-// TODO: Maicheal — exposes profile endpoints
+// DONE: Maicheal — exposes profile endpoints
 // All routes here require a valid JWT token (configured in SecurityConfig)
 
 @RestController
@@ -19,27 +21,32 @@ public class ProfileController {
         this.profileService = profileService;
     }
 
-    // TODO: extract the logged-in user's ID from the JWT (Spring Security principal)
-    // TODO: call profileService.getProfile(userId)
-    // TODO: return 200 with the Profile
+    // DONE: extract the logged-in user's ID from the JWT (Spring Security principal)
+    // DONE: call profileService.getProfile(userId)
+    // DONE: return 200 with the Profile
     @GetMapping
-    public ResponseEntity<Profile> getMyProfile() {
-        return null;
+    public ResponseEntity<Profile> getMyProfile(Authentication authentication) {
+        // getName() returns the email stored in the JWT by JwtAuthFilter
+        return ResponseEntity.ok(profileService.getProfile(authentication.getName()));
     }
 
-    // TODO: extract the logged-in user's ID from the JWT
-    // TODO: call profileService.createProfile(userId, request)
-    // TODO: return 201 with the created Profile
+    // DONE: extract the logged-in user's ID from the JWT
+    // DONE: call profileService.createProfile(userId, request)
+    // DONE: return 201 with the created Profile
     @PostMapping
-    public ResponseEntity<Profile> createProfile(@RequestBody ProfileRequest request) {
-        return null;
+    public ResponseEntity<Profile> createProfile(Authentication authentication,
+                                                  @RequestBody ProfileRequest request) {
+        // 201 Created is more precise than 200 OK for resource creation
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(profileService.createProfile(authentication.getName(), request));
     }
 
-    // TODO: extract the logged-in user's ID from the JWT
-    // TODO: call profileService.updateProfile(userId, request)
-    // TODO: return 200 with the updated Profile
+    // DONE: extract the logged-in user's ID from the JWT
+    // DONE: call profileService.updateProfile(userId, request)
+    // DONE: return 200 with the updated Profile
     @PutMapping
-    public ResponseEntity<Profile> updateProfile(@RequestBody ProfileRequest request) {
-        return null;
+    public ResponseEntity<Profile> updateProfile(Authentication authentication,
+                                                  @RequestBody ProfileRequest request) {
+        return ResponseEntity.ok(profileService.updateProfile(authentication.getName(), request));
     }
 }

--- a/src/main/java/com/github/wsustudygroupapp/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/github/wsustudygroupapp/exception/ResourceNotFoundException.java
@@ -1,0 +1,16 @@
+package com.github.wsustudygroupapp.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Thrown when a requested resource (user, profile, course) does not exist in the database.
+ * @ResponseStatus maps this exception to a 404 Not Found HTTP response automatically.
+ */
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/github/wsustudygroupapp/repository/UserCourseRepository.java
+++ b/src/main/java/com/github/wsustudygroupapp/repository/UserCourseRepository.java
@@ -18,6 +18,9 @@ public interface UserCourseRepository extends JpaRepository<UserCourse, Long> {
     /** Returns all course enrollments for a given student profile. */
     List<UserCourse> findByProfileId(Long profileId);
 
+    /** Returns true if the student is already enrolled in this course+section+semester. Used to prevent duplicate enrollments. */
+    boolean existsByProfileIdAndCourseIdAndSectionAndSemester(Long profileId, Long courseId, String section, String semester);
+
     /**
      * Core matching query — finds all students enrolled in the same course, section, and semester.
      * Excludes the requesting student's own profile from the results.

--- a/src/main/java/com/github/wsustudygroupapp/service/CourseService.java
+++ b/src/main/java/com/github/wsustudygroupapp/service/CourseService.java
@@ -1,12 +1,17 @@
 package com.github.wsustudygroupapp.service;
 
 import com.github.wsustudygroupapp.dto.CourseEnrollRequest;
+import com.github.wsustudygroupapp.exception.ResourceNotFoundException;
 import com.github.wsustudygroupapp.model.Course;
+import com.github.wsustudygroupapp.model.Profile;
 import com.github.wsustudygroupapp.model.UserCourse;
 import com.github.wsustudygroupapp.repository.CourseRepository;
 import com.github.wsustudygroupapp.repository.ProfileRepository;
 import com.github.wsustudygroupapp.repository.UserCourseRepository;
+import com.github.wsustudygroupapp.repository.UserRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -23,44 +28,96 @@ public class CourseService {
     private final CourseRepository courseRepository;
     private final UserCourseRepository userCourseRepository;
     private final ProfileRepository profileRepository;
+    private final UserRepository userRepository;
 
     public CourseService(CourseRepository courseRepository,
                          UserCourseRepository userCourseRepository,
-                         ProfileRepository profileRepository) {
+                         ProfileRepository profileRepository,
+                         UserRepository userRepository) {
         this.courseRepository = courseRepository;
         this.userCourseRepository = userCourseRepository;
         this.profileRepository = profileRepository;
+        this.userRepository = userRepository;
     }
 
-    // TODO: return courseRepository.findAll()
+    // DONE: return courseRepository.findAll()
     public List<Course> getAllCourses() {
-        return null;
+        return courseRepository.findAll();
     }
 
-    // TODO: return userCourseRepository.findByProfileId(profileId)
-    public List<UserCourse> getMyCourses(Long profileId) {
-        return null;
+    // DONE: return userCourseRepository.findByProfileId(profileId)
+    public List<UserCourse> getMyCourses(String email) {
+        // resolve profile from the logged-in user's email
+        Profile profile = resolveProfile(email);
+        return userCourseRepository.findByProfileId(profile.getId());
     }
 
-    // TODO: find the course by courseCode using courseRepository.findByCourseCode()
-    // TODO: find the profile by profileId
-    // TODO: build a new UserCourse with the course, profile, section, semester
-    // TODO: save and return it
-    public UserCourse enroll(Long profileId, CourseEnrollRequest request) {
-        return null;
+    // DONE: find the course by courseCode using courseRepository.findByCourseCode()
+    // DONE: find the profile by profileId
+    // DONE: build a new UserCourse with the course, profile, section, semester
+    // DONE: save and return it
+    public UserCourse enroll(String email, CourseEnrollRequest request) {
+        Profile profile = resolveProfile(email);
+        Course course = courseRepository.findByCourseCode(request.getCourseCode())
+                .orElseThrow(() -> new ResourceNotFoundException("Course not found: " + request.getCourseCode()));
+        // prevent the same student from enrolling in the same course+section+semester twice
+        if (userCourseRepository.existsByProfileIdAndCourseIdAndSectionAndSemester(
+                profile.getId(), course.getId(), request.getSection(), request.getSemester())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Already enrolled in this course section");
+        }
+        UserCourse enrollment = new UserCourse();
+        enrollment.setProfile(profile);
+        enrollment.setCourse(course);
+        enrollment.setSection(request.getSection());
+        enrollment.setSemester(request.getSemester());
+        return userCourseRepository.save(enrollment);
     }
 
-    // TODO: find the UserCourse by its ID
-    // TODO: confirm it belongs to this profileId (security check)
-    // TODO: delete it
-    public void drop(Long userCourseId, Long profileId) {
-
+    // DONE: find the UserCourse by its ID
+    // DONE: confirm it belongs to this profileId (security check)
+    // DONE: delete it
+    public void drop(Long userCourseId, String email) {
+        Profile profile = resolveProfile(email);
+        UserCourse enrollment = userCourseRepository.findById(userCourseId)
+                .orElseThrow(() -> new ResourceNotFoundException("Enrollment not found: " + userCourseId));
+        // ensure students can only drop their own enrollments, not someone else's
+        if (!enrollment.getProfile().getId().equals(profile.getId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You can only drop your own enrollments");
+        }
+        userCourseRepository.delete(enrollment);
     }
 
-    // TODO: find the UserCourse by ID to get courseId, section, semester
-    // TODO: call userCourseRepository.findClassmates(courseId, section, semester, profileId)
-    // TODO: return the list
-    public List<UserCourse> getClassmates(Long userCourseId, Long profileId) {
-        return null;
+    // DONE: find the UserCourse by ID to get courseId, section, semester
+    // DONE: call userCourseRepository.findClassmates(courseId, section, semester, profileId)
+    // DONE: return the list
+    public List<UserCourse> getClassmates(Long userCourseId, String email) {
+        Profile profile = resolveProfile(email);
+        UserCourse enrollment = userCourseRepository.findById(userCourseId)
+                .orElseThrow(() -> new ResourceNotFoundException("Enrollment not found: " + userCourseId));
+        // find all students in the same course, section, and semester (excluding the requester)
+        return userCourseRepository.findClassmates(
+                enrollment.getCourse().getId(),
+                enrollment.getSection(),
+                enrollment.getSemester(),
+                profile.getId());
+    }
+
+    // Plan C — search courses by keyword (e.g. "biology"), used for the frontend search bar
+    public List<Course> searchCourses(String keyword) {
+        return courseRepository.findByCourseNameContainingIgnoreCase(keyword);
+    }
+
+    // Plan C — filter courses by department code (e.g. "CAIS"), used for the frontend dropdown
+    public List<Course> getCoursesByDepartment(String departmentCode) {
+        return courseRepository.findByDepartmentCode(departmentCode);
+    }
+
+    // resolves the logged-in user's Profile from their email — throws 404 if not found
+    private Profile resolveProfile(String email) {
+        Long userId = userRepository.findByEmail(email)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found: " + email))
+                .getId();
+        return profileRepository.findByUserId(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("Profile not found for: " + email));
     }
 }

--- a/src/main/java/com/github/wsustudygroupapp/service/ProfileService.java
+++ b/src/main/java/com/github/wsustudygroupapp/service/ProfileService.java
@@ -1,11 +1,14 @@
 package com.github.wsustudygroupapp.service;
 
 import com.github.wsustudygroupapp.dto.ProfileRequest;
+import com.github.wsustudygroupapp.exception.ResourceNotFoundException;
 import com.github.wsustudygroupapp.model.Profile;
+import com.github.wsustudygroupapp.model.User;
 import com.github.wsustudygroupapp.repository.ProfileRepository;
+import com.github.wsustudygroupapp.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
-// TODO: Maicheal — handles profile creation and updates
+// DONE: Maicheal — handles profile creation and updates
 // getProfile() → return a student's profile by their user ID
 // createProfile() → called after registration to set up name, major, year, bio
 // updateProfile() → let the student edit their profile later
@@ -14,28 +17,55 @@ import org.springframework.stereotype.Service;
 public class ProfileService {
 
     private final ProfileRepository profileRepository;
+    private final UserRepository userRepository;
 
-    public ProfileService(ProfileRepository profileRepository) {
+    public ProfileService(ProfileRepository profileRepository, UserRepository userRepository) {
         this.profileRepository = profileRepository;
+        this.userRepository = userRepository;
     }
 
-    // TODO: find profile by userId using profileRepository.findByUserId(userId)
-    // TODO: throw exception if not found
-    public Profile getProfile(Long userId) {
-        return null;
+    // DONE: find profile by userId using profileRepository.findByUserId(userId)
+    // DONE: throw exception if not found
+    public Profile getProfile(String email) {
+        // look up the User by email — throws 404 if account doesn't exist
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found: " + email));
+        // look up the Profile linked to that user — throws 404 if onboarding was never completed
+        return profileRepository.findByUserId(user.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Profile not found for: " + email));
     }
 
-    // TODO: build a new Profile from the request fields (name, major, year, bio)
-    // TODO: link the profile to the User with the given userId
-    // TODO: save and return the profile
-    public Profile createProfile(Long userId, ProfileRequest request) {
-        return null;
+    // DONE: build a new Profile from the request fields (name, major, year, bio)
+    // DONE: link the profile to the User with the given userId
+    // DONE: save and return the profile
+    public Profile createProfile(String email, ProfileRequest request) {
+        // resolve the User account so we can link the profile to it
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found: " + email));
+        // build and populate the new profile from the request body
+        Profile profile = new Profile();
+        profile.setUser(user);
+        profile.setName(request.getName());
+        profile.setMajor(request.getMajor());
+        profile.setYear(request.getYear());
+        profile.setBio(request.getBio());
+        return profileRepository.save(profile);
     }
 
-    // TODO: find the existing profile by userId
-    // TODO: update fields from the request
-    // TODO: save and return the updated profile
-    public Profile updateProfile(Long userId, ProfileRequest request) {
-        return null;
+    // DONE: find the existing profile by userId
+    // DONE: update fields from the request
+    // DONE: save and return the updated profile
+    public Profile updateProfile(String email, ProfileRequest request) {
+        // resolve the User and their existing profile — both must exist
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found: " + email));
+        Profile profile = profileRepository.findByUserId(user.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Profile not found for: " + email));
+        // overwrite all fields with the new values from the request
+        profile.setName(request.getName());
+        profile.setMajor(request.getMajor());
+        profile.setYear(request.getYear());
+        profile.setBio(request.getBio());
+        return profileRepository.save(profile);
     }
 }

--- a/src/test/java/com/github/wsustudygroupapp/controller/CourseControllerTest.java
+++ b/src/test/java/com/github/wsustudygroupapp/controller/CourseControllerTest.java
@@ -1,0 +1,273 @@
+package com.github.wsustudygroupapp.controller;
+
+import com.github.wsustudygroupapp.dto.CourseEnrollRequest;
+import com.github.wsustudygroupapp.exception.ResourceNotFoundException;
+import com.github.wsustudygroupapp.model.Course;
+import com.github.wsustudygroupapp.model.UserCourse;
+import com.github.wsustudygroupapp.service.CourseService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CourseControllerTest {
+
+    @Mock private CourseService courseService;
+    @Mock private Authentication authentication;
+    @InjectMocks private CourseController courseController;
+
+    private static final String EMAIL = "test@westfield.ma.edu";
+    private Course mockCourse;
+    private UserCourse mockEnrollment;
+    private CourseEnrollRequest enrollRequest;
+
+    @BeforeEach
+    void setUp() {
+        // authentication stub is applied per-test via mockAuth() — not here,
+        // because some tests (getAllCourses, search, department) don't use authentication
+
+        mockCourse = new Course();
+        mockCourse.setId(10L);
+        mockCourse.setCourseCode("CAIS 0236");
+        mockCourse.setCourseName("Computer Organization and Architecture");
+        mockCourse.setDepartmentCode("CAIS");
+
+        mockEnrollment = new UserCourse();
+        mockEnrollment.setId(100L);
+        mockEnrollment.setSection("001");
+        mockEnrollment.setSemester("Fall 2026");
+
+        enrollRequest = new CourseEnrollRequest();
+        enrollRequest.setCourseCode("CAIS 0236");
+        enrollRequest.setSection("001");
+        enrollRequest.setSemester("Fall 2026");
+    }
+
+    // stubs authentication.getName() — only called in tests that pass authentication to the controller
+    private void mockAuth() {
+        when(authentication.getName()).thenReturn(EMAIL);
+    }
+
+    // ── GET /courses ───────────────────────────────────────────────────────────
+
+    @Test
+    void getAllCourses_returns200WithCourseList() {
+        when(courseService.getAllCourses()).thenReturn(List.of(mockCourse));
+        ResponseEntity<List<Course>> response = courseController.getAllCourses();
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1, response.getBody().size());
+    }
+
+    @Test
+    void getAllCourses_emptyCatalog_returns200WithEmptyList() {
+        when(courseService.getAllCourses()).thenReturn(List.of());
+        ResponseEntity<List<Course>> response = courseController.getAllCourses();
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody().isEmpty());
+    }
+
+    // ── GET /courses/my ────────────────────────────────────────────────────────
+
+    @Test
+    void getMyCourses_returns200WithEnrollmentList() {
+        mockAuth();
+        when(courseService.getMyCourses(EMAIL)).thenReturn(List.of(mockEnrollment));
+        ResponseEntity<List<UserCourse>> response = courseController.getMyCourses(authentication);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1, response.getBody().size());
+    }
+
+    @Test
+    void getMyCourses_passesEmailFromPrincipalToService() {
+        mockAuth();
+        when(courseService.getMyCourses(EMAIL)).thenReturn(List.of());
+        courseController.getMyCourses(authentication);
+        verify(courseService, times(1)).getMyCourses(EMAIL);
+    }
+
+    @Test
+    void getMyCourses_profileNotFound_propagatesResourceNotFoundException() {
+        mockAuth();
+        when(courseService.getMyCourses(EMAIL))
+                .thenThrow(new ResourceNotFoundException("Profile not found"));
+        assertThrows(ResourceNotFoundException.class,
+                () -> courseController.getMyCourses(authentication));
+    }
+
+    // ── POST /courses/enroll ───────────────────────────────────────────────────
+
+    @Test
+    void enroll_returns201WithCreatedEnrollment() {
+        mockAuth();
+        when(courseService.enroll(eq(EMAIL), any(CourseEnrollRequest.class))).thenReturn(mockEnrollment);
+        ResponseEntity<UserCourse> response = courseController.enroll(authentication, enrollRequest);
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertEquals(mockEnrollment, response.getBody());
+    }
+
+    @Test
+    void enroll_doesNotReturn200_mustBe201() {
+        mockAuth();
+        when(courseService.enroll(eq(EMAIL), any(CourseEnrollRequest.class))).thenReturn(mockEnrollment);
+        ResponseEntity<UserCourse> response = courseController.enroll(authentication, enrollRequest);
+        assertNotEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void enroll_courseNotFound_propagatesResourceNotFoundException() {
+        mockAuth();
+        when(courseService.enroll(eq(EMAIL), any(CourseEnrollRequest.class)))
+                .thenThrow(new ResourceNotFoundException("Course not found"));
+        assertThrows(ResourceNotFoundException.class,
+                () -> courseController.enroll(authentication, enrollRequest));
+    }
+
+    @Test
+    void enroll_duplicateEnrollment_propagates409ConflictException() {
+        mockAuth();
+        when(courseService.enroll(eq(EMAIL), any(CourseEnrollRequest.class)))
+                .thenThrow(new ResponseStatusException(HttpStatus.CONFLICT, "Already enrolled"));
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> courseController.enroll(authentication, enrollRequest));
+        assertEquals(HttpStatus.CONFLICT, ex.getStatusCode());
+    }
+
+    @Test
+    void enroll_passesEmailAndRequestToService() {
+        mockAuth();
+        when(courseService.enroll(eq(EMAIL), eq(enrollRequest))).thenReturn(mockEnrollment);
+        courseController.enroll(authentication, enrollRequest);
+        verify(courseService, times(1)).enroll(EMAIL, enrollRequest);
+    }
+
+    // ── DELETE /courses/{userCourseId} ─────────────────────────────────────────
+
+    @Test
+    void drop_ownEnrollment_returns204NoContent() {
+        mockAuth();
+        doNothing().when(courseService).drop(100L, EMAIL);
+        ResponseEntity<Void> response = courseController.drop(authentication, 100L);
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        assertNull(response.getBody());
+    }
+
+    @Test
+    void drop_passesEnrollmentIdAndEmailToService() {
+        mockAuth();
+        doNothing().when(courseService).drop(100L, EMAIL);
+        courseController.drop(authentication, 100L);
+        verify(courseService, times(1)).drop(100L, EMAIL);
+    }
+
+    @Test
+    void drop_enrollmentNotFound_propagatesResourceNotFoundException() {
+        mockAuth();
+        doThrow(new ResourceNotFoundException("Enrollment not found"))
+                .when(courseService).drop(100L, EMAIL);
+        assertThrows(ResourceNotFoundException.class,
+                () -> courseController.drop(authentication, 100L));
+    }
+
+    @Test
+    void drop_enrollmentOwnedByAnotherStudent_propagates403ForbiddenException() {
+        mockAuth();
+        doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Not your enrollment"))
+                .when(courseService).drop(100L, EMAIL);
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> courseController.drop(authentication, 100L));
+        assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
+    }
+
+    // ── GET /courses/{userCourseId}/classmates ─────────────────────────────────
+
+    @Test
+    void getClassmates_returns200WithClassmateList() {
+        mockAuth();
+        when(courseService.getClassmates(100L, EMAIL)).thenReturn(List.of(mockEnrollment));
+        ResponseEntity<List<UserCourse>> response = courseController.getClassmates(authentication, 100L);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1, response.getBody().size());
+    }
+
+    @Test
+    void getClassmates_noClassmates_returns200WithEmptyList() {
+        mockAuth();
+        when(courseService.getClassmates(100L, EMAIL)).thenReturn(List.of());
+        ResponseEntity<List<UserCourse>> response = courseController.getClassmates(authentication, 100L);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody().isEmpty());
+    }
+
+    @Test
+    void getClassmates_enrollmentNotFound_propagatesResourceNotFoundException() {
+        mockAuth();
+        when(courseService.getClassmates(100L, EMAIL))
+                .thenThrow(new ResourceNotFoundException("Enrollment not found"));
+        assertThrows(ResourceNotFoundException.class,
+                () -> courseController.getClassmates(authentication, 100L));
+    }
+
+    // ── GET /courses/search ────────────────────────────────────────────────────
+
+    @Test
+    void searchCourses_returns200WithResults() {
+        when(courseService.searchCourses("biology")).thenReturn(List.of(mockCourse));
+        ResponseEntity<List<Course>> response = courseController.searchCourses("biology");
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1, response.getBody().size());
+    }
+
+    @Test
+    void searchCourses_noMatches_returns200WithEmptyList() {
+        when(courseService.searchCourses("zzzz")).thenReturn(List.of());
+        ResponseEntity<List<Course>> response = courseController.searchCourses("zzzz");
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody().isEmpty());
+    }
+
+    @Test
+    void searchCourses_passesKeywordToService() {
+        when(courseService.searchCourses("biology")).thenReturn(List.of());
+        courseController.searchCourses("biology");
+        verify(courseService, times(1)).searchCourses("biology");
+    }
+
+    // ── GET /courses/department/{code} ─────────────────────────────────────────
+
+    @Test
+    void getCoursesByDepartment_returns200WithFilteredList() {
+        when(courseService.getCoursesByDepartment("CAIS")).thenReturn(List.of(mockCourse));
+        ResponseEntity<List<Course>> response = courseController.getCoursesByDepartment("CAIS");
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1, response.getBody().size());
+    }
+
+    @Test
+    void getCoursesByDepartment_unknownDepartment_returns200WithEmptyList() {
+        when(courseService.getCoursesByDepartment("FAKE")).thenReturn(List.of());
+        ResponseEntity<List<Course>> response = courseController.getCoursesByDepartment("FAKE");
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody().isEmpty());
+    }
+
+    @Test
+    void getCoursesByDepartment_passesDepartmentCodeToService() {
+        when(courseService.getCoursesByDepartment("MATH")).thenReturn(List.of());
+        courseController.getCoursesByDepartment("MATH");
+        verify(courseService, times(1)).getCoursesByDepartment("MATH");
+    }
+}

--- a/src/test/java/com/github/wsustudygroupapp/controller/ProfileControllerTest.java
+++ b/src/test/java/com/github/wsustudygroupapp/controller/ProfileControllerTest.java
@@ -1,0 +1,153 @@
+package com.github.wsustudygroupapp.controller;
+
+import com.github.wsustudygroupapp.dto.ProfileRequest;
+import com.github.wsustudygroupapp.exception.ResourceNotFoundException;
+import com.github.wsustudygroupapp.model.Profile;
+import com.github.wsustudygroupapp.service.ProfileService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileControllerTest {
+
+    @Mock private ProfileService profileService;
+    @Mock private Authentication authentication;
+    @InjectMocks private ProfileController profileController;
+
+    private static final String EMAIL = "test@westfield.ma.edu";
+    private Profile mockProfile;
+    private ProfileRequest profileRequest;
+
+    @BeforeEach
+    void setUp() {
+        // lenient — not every test uses authentication (avoids UnnecessaryStubbingException)
+        lenient().when(authentication.getName()).thenReturn(EMAIL);
+
+        mockProfile = new Profile();
+        mockProfile.setId(1L);
+        mockProfile.setName("Test User");
+        mockProfile.setMajor("Computer Science");
+        mockProfile.setYear("Junior");
+        mockProfile.setBio("Test bio");
+
+        profileRequest = new ProfileRequest();
+        profileRequest.setName("Test User");
+        profileRequest.setMajor("Computer Science");
+        profileRequest.setYear("Junior");
+        profileRequest.setBio("Test bio");
+    }
+
+    // ── GET /profile ──────────────────────────────────────────────────────────
+
+    @Test
+    void getMyProfile_returns200WithProfile() {
+        when(profileService.getProfile(EMAIL)).thenReturn(mockProfile);
+        ResponseEntity<Profile> response = profileController.getMyProfile(authentication);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(mockProfile, response.getBody());
+    }
+
+    @Test
+    void getMyProfile_passesEmailFromPrincipalToService() {
+        when(profileService.getProfile(EMAIL)).thenReturn(mockProfile);
+        profileController.getMyProfile(authentication);
+        verify(profileService, times(1)).getProfile(EMAIL);
+    }
+
+    @Test
+    void getMyProfile_profileNotFound_propagatesResourceNotFoundException() {
+        // exception propagates up — Spring MVC maps @ResponseStatus(404) to HTTP 404
+        when(profileService.getProfile(EMAIL))
+                .thenThrow(new ResourceNotFoundException("Profile not found"));
+        assertThrows(ResourceNotFoundException.class,
+                () -> profileController.getMyProfile(authentication));
+    }
+
+    @Test
+    void getMyProfile_userNotFound_propagatesResourceNotFoundException() {
+        when(profileService.getProfile(EMAIL))
+                .thenThrow(new ResourceNotFoundException("User not found: " + EMAIL));
+        ResourceNotFoundException ex = assertThrows(ResourceNotFoundException.class,
+                () -> profileController.getMyProfile(authentication));
+        assertTrue(ex.getMessage().contains(EMAIL));
+    }
+
+    // ── POST /profile ─────────────────────────────────────────────────────────
+
+    @Test
+    void createProfile_returns201WithCreatedProfile() {
+        when(profileService.createProfile(eq(EMAIL), any(ProfileRequest.class))).thenReturn(mockProfile);
+        ResponseEntity<Profile> response = profileController.createProfile(authentication, profileRequest);
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertEquals(mockProfile, response.getBody());
+    }
+
+    @Test
+    void createProfile_passesEmailAndRequestBodyToService() {
+        when(profileService.createProfile(eq(EMAIL), eq(profileRequest))).thenReturn(mockProfile);
+        profileController.createProfile(authentication, profileRequest);
+        verify(profileService, times(1)).createProfile(EMAIL, profileRequest);
+    }
+
+    @Test
+    void createProfile_userNotFound_propagatesResourceNotFoundException() {
+        when(profileService.createProfile(eq(EMAIL), any(ProfileRequest.class)))
+                .thenThrow(new ResourceNotFoundException("User not found"));
+        assertThrows(ResourceNotFoundException.class,
+                () -> profileController.createProfile(authentication, profileRequest));
+    }
+
+    @Test
+    void createProfile_doesNotReturn200_mustBe201() {
+        // creating a resource must return 201, not 200
+        when(profileService.createProfile(eq(EMAIL), any(ProfileRequest.class))).thenReturn(mockProfile);
+        ResponseEntity<Profile> response = profileController.createProfile(authentication, profileRequest);
+        assertNotEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    }
+
+    // ── PUT /profile ──────────────────────────────────────────────────────────
+
+    @Test
+    void updateProfile_returns200WithUpdatedProfile() {
+        when(profileService.updateProfile(eq(EMAIL), any(ProfileRequest.class))).thenReturn(mockProfile);
+        ResponseEntity<Profile> response = profileController.updateProfile(authentication, profileRequest);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(mockProfile, response.getBody());
+    }
+
+    @Test
+    void updateProfile_passesEmailAndRequestBodyToService() {
+        when(profileService.updateProfile(eq(EMAIL), eq(profileRequest))).thenReturn(mockProfile);
+        profileController.updateProfile(authentication, profileRequest);
+        verify(profileService, times(1)).updateProfile(EMAIL, profileRequest);
+    }
+
+    @Test
+    void updateProfile_profileNotFound_propagatesResourceNotFoundException() {
+        when(profileService.updateProfile(eq(EMAIL), any(ProfileRequest.class)))
+                .thenThrow(new ResourceNotFoundException("Profile not found"));
+        assertThrows(ResourceNotFoundException.class,
+                () -> profileController.updateProfile(authentication, profileRequest));
+    }
+
+    @Test
+    void updateProfile_userNotFound_propagatesResourceNotFoundException() {
+        when(profileService.updateProfile(eq(EMAIL), any(ProfileRequest.class)))
+                .thenThrow(new ResourceNotFoundException("User not found: " + EMAIL));
+        assertThrows(ResourceNotFoundException.class,
+                () -> profileController.updateProfile(authentication, profileRequest));
+    }
+}

--- a/src/test/java/com/github/wsustudygroupapp/service/CourseServiceTest.java
+++ b/src/test/java/com/github/wsustudygroupapp/service/CourseServiceTest.java
@@ -1,0 +1,338 @@
+package com.github.wsustudygroupapp.service;
+
+import com.github.wsustudygroupapp.dto.CourseEnrollRequest;
+import com.github.wsustudygroupapp.exception.ResourceNotFoundException;
+import com.github.wsustudygroupapp.model.Course;
+import com.github.wsustudygroupapp.model.Profile;
+import com.github.wsustudygroupapp.model.User;
+import com.github.wsustudygroupapp.model.UserCourse;
+import com.github.wsustudygroupapp.repository.CourseRepository;
+import com.github.wsustudygroupapp.repository.ProfileRepository;
+import com.github.wsustudygroupapp.repository.UserCourseRepository;
+import com.github.wsustudygroupapp.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CourseServiceTest {
+
+    @Mock private CourseRepository courseRepository;
+    @Mock private UserCourseRepository userCourseRepository;
+    @Mock private ProfileRepository profileRepository;
+    @Mock private UserRepository userRepository;
+    @InjectMocks private CourseService courseService;
+
+    private static final String EMAIL = "test@westfield.ma.edu";
+    private static final String UNKNOWN_EMAIL = "ghost@westfield.ma.edu";
+
+    private User mockUser;
+    private Profile mockProfile;
+    private Profile otherProfile;
+    private Course mockCourse;
+    private UserCourse mockEnrollment;
+    private CourseEnrollRequest enrollRequest;
+
+    @BeforeEach
+    void setUp() {
+        mockUser = new User();
+        mockUser.setId(1L);
+        mockUser.setEmail(EMAIL);
+
+        mockProfile = new Profile();
+        mockProfile.setId(1L);
+        mockProfile.setUser(mockUser);
+
+        otherProfile = new Profile();
+        otherProfile.setId(99L);
+
+        mockCourse = new Course();
+        mockCourse.setId(10L);
+        mockCourse.setCourseCode("CAIS 0236");
+        mockCourse.setCourseName("Computer Organization and Architecture");
+        mockCourse.setDepartmentCode("CAIS");
+
+        mockEnrollment = new UserCourse();
+        mockEnrollment.setId(100L);
+        mockEnrollment.setProfile(mockProfile);
+        mockEnrollment.setCourse(mockCourse);
+        mockEnrollment.setSection("001");
+        mockEnrollment.setSemester("Fall 2026");
+
+        enrollRequest = new CourseEnrollRequest();
+        enrollRequest.setCourseCode("CAIS 0236");
+        enrollRequest.setSection("001");
+        enrollRequest.setSemester("Fall 2026");
+    }
+
+    // stubs the resolveProfile() helper used by most service methods
+    private void stubResolveProfile() {
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(mockUser));
+        when(profileRepository.findByUserId(1L)).thenReturn(Optional.of(mockProfile));
+    }
+
+    // ── getAllCourses ──────────────────────────────────────────────────────────
+
+    @Test
+    void getAllCourses_returnsFullCatalogFromRepo() {
+        when(courseRepository.findAll()).thenReturn(List.of(mockCourse));
+        assertEquals(List.of(mockCourse), courseService.getAllCourses());
+    }
+
+    @Test
+    void getAllCourses_emptyCatalog_returnsEmptyList() {
+        when(courseRepository.findAll()).thenReturn(List.of());
+        assertTrue(courseService.getAllCourses().isEmpty());
+    }
+
+    // ── getMyCourses ───────────────────────────────────────────────────────────
+
+    @Test
+    void getMyCourses_userNotFound_throwsResourceNotFoundException() {
+        when(userRepository.findByEmail(UNKNOWN_EMAIL)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class,
+                () -> courseService.getMyCourses(UNKNOWN_EMAIL));
+    }
+
+    @Test
+    void getMyCourses_profileNotFound_throwsResourceNotFoundException() {
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(mockUser));
+        when(profileRepository.findByUserId(1L)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class,
+                () -> courseService.getMyCourses(EMAIL));
+    }
+
+    @Test
+    void getMyCourses_returnsEnrollmentsForCorrectProfile() {
+        stubResolveProfile();
+        when(userCourseRepository.findByProfileId(1L)).thenReturn(List.of(mockEnrollment));
+        assertEquals(List.of(mockEnrollment), courseService.getMyCourses(EMAIL));
+    }
+
+    @Test
+    void getMyCourses_studentNotEnrolledInAnything_returnsEmptyList() {
+        stubResolveProfile();
+        when(userCourseRepository.findByProfileId(1L)).thenReturn(List.of());
+        assertTrue(courseService.getMyCourses(EMAIL).isEmpty());
+    }
+
+    // ── enroll ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void enroll_userNotFound_throwsResourceNotFoundException() {
+        when(userRepository.findByEmail(UNKNOWN_EMAIL)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class,
+                () -> courseService.enroll(UNKNOWN_EMAIL, enrollRequest));
+    }
+
+    @Test
+    void enroll_courseCodeNotInCatalog_throwsResourceNotFoundException() {
+        stubResolveProfile();
+        when(courseRepository.findByCourseCode("CAIS 0236")).thenReturn(Optional.empty());
+        ResourceNotFoundException ex = assertThrows(ResourceNotFoundException.class,
+                () -> courseService.enroll(EMAIL, enrollRequest));
+        assertTrue(ex.getMessage().contains("CAIS 0236"));
+    }
+
+    @Test
+    void enroll_alreadyEnrolledInSameSectionAndSemester_throws409Conflict() {
+        stubResolveProfile();
+        when(courseRepository.findByCourseCode("CAIS 0236")).thenReturn(Optional.of(mockCourse));
+        when(userCourseRepository.existsByProfileIdAndCourseIdAndSectionAndSemester(
+                1L, 10L, "001", "Fall 2026")).thenReturn(true);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> courseService.enroll(EMAIL, enrollRequest));
+        assertEquals(HttpStatus.CONFLICT, ex.getStatusCode());
+    }
+
+    @Test
+    void enroll_differentSectionSameCourse_doesNotThrowConflict() {
+        // enrolling in a different section of the same course should be allowed
+        stubResolveProfile();
+        CourseEnrollRequest differentSection = new CourseEnrollRequest();
+        differentSection.setCourseCode("CAIS 0236");
+        differentSection.setSection("002");
+        differentSection.setSemester("Fall 2026");
+
+        when(courseRepository.findByCourseCode("CAIS 0236")).thenReturn(Optional.of(mockCourse));
+        when(userCourseRepository.existsByProfileIdAndCourseIdAndSectionAndSemester(
+                1L, 10L, "002", "Fall 2026")).thenReturn(false);
+        when(userCourseRepository.save(any(UserCourse.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        assertDoesNotThrow(() -> courseService.enroll(EMAIL, differentSection));
+    }
+
+    @Test
+    void enroll_setsAllFieldsOnNewEnrollment() {
+        stubResolveProfile();
+        when(courseRepository.findByCourseCode("CAIS 0236")).thenReturn(Optional.of(mockCourse));
+        when(userCourseRepository.existsByProfileIdAndCourseIdAndSectionAndSemester(
+                1L, 10L, "001", "Fall 2026")).thenReturn(false);
+        when(userCourseRepository.save(any(UserCourse.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        UserCourse result = courseService.enroll(EMAIL, enrollRequest);
+
+        assertEquals(mockProfile, result.getProfile());
+        assertEquals(mockCourse, result.getCourse());
+        assertEquals("001", result.getSection());
+        assertEquals("Fall 2026", result.getSemester());
+    }
+
+    @Test
+    void enroll_persistsEnrollmentExactlyOnce() {
+        stubResolveProfile();
+        when(courseRepository.findByCourseCode("CAIS 0236")).thenReturn(Optional.of(mockCourse));
+        when(userCourseRepository.existsByProfileIdAndCourseIdAndSectionAndSemester(
+                1L, 10L, "001", "Fall 2026")).thenReturn(false);
+        when(userCourseRepository.save(any(UserCourse.class))).thenReturn(mockEnrollment);
+
+        courseService.enroll(EMAIL, enrollRequest);
+
+        verify(userCourseRepository, times(1)).save(any(UserCourse.class));
+    }
+
+    // ── drop ───────────────────────────────────────────────────────────────────
+
+    @Test
+    void drop_userNotFound_throwsResourceNotFoundException() {
+        when(userRepository.findByEmail(UNKNOWN_EMAIL)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class,
+                () -> courseService.drop(100L, UNKNOWN_EMAIL));
+    }
+
+    @Test
+    void drop_enrollmentNotFound_throwsResourceNotFoundException() {
+        stubResolveProfile();
+        when(userCourseRepository.findById(100L)).thenReturn(Optional.empty());
+        ResourceNotFoundException ex = assertThrows(ResourceNotFoundException.class,
+                () -> courseService.drop(100L, EMAIL));
+        assertTrue(ex.getMessage().contains("100"));
+    }
+
+    @Test
+    void drop_enrollmentOwnedByAnotherStudent_throws403Forbidden() {
+        stubResolveProfile();
+        // enrollment belongs to a different profile
+        mockEnrollment.setProfile(otherProfile);
+        when(userCourseRepository.findById(100L)).thenReturn(Optional.of(mockEnrollment));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> courseService.drop(100L, EMAIL));
+        assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
+    }
+
+    @Test
+    void drop_enrollmentOwnedByAnotherStudent_doesNotDelete() {
+        // must not delete anything if the ownership check fails
+        stubResolveProfile();
+        mockEnrollment.setProfile(otherProfile);
+        when(userCourseRepository.findById(100L)).thenReturn(Optional.of(mockEnrollment));
+
+        assertThrows(ResponseStatusException.class, () -> courseService.drop(100L, EMAIL));
+        verify(userCourseRepository, never()).delete(any());
+    }
+
+    @Test
+    void drop_ownEnrollment_deletesCorrectRecord() {
+        stubResolveProfile();
+        when(userCourseRepository.findById(100L)).thenReturn(Optional.of(mockEnrollment));
+
+        courseService.drop(100L, EMAIL);
+
+        verify(userCourseRepository, times(1)).delete(mockEnrollment);
+    }
+
+    // ── getClassmates ──────────────────────────────────────────────────────────
+
+    @Test
+    void getClassmates_enrollmentNotFound_throwsResourceNotFoundException() {
+        stubResolveProfile();
+        when(userCourseRepository.findById(100L)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class,
+                () -> courseService.getClassmates(100L, EMAIL));
+    }
+
+    @Test
+    void getClassmates_queriesRepoWithCorrectCourseAndSectionAndSemester() {
+        stubResolveProfile();
+        when(userCourseRepository.findById(100L)).thenReturn(Optional.of(mockEnrollment));
+        when(userCourseRepository.findClassmates(10L, "001", "Fall 2026", 1L))
+                .thenReturn(List.of());
+
+        courseService.getClassmates(100L, EMAIL);
+
+        // verify the correct values are passed to the matching query
+        verify(userCourseRepository).findClassmates(10L, "001", "Fall 2026", 1L);
+    }
+
+    @Test
+    void getClassmates_returnsClassmatesFromRepo() {
+        stubResolveProfile();
+        UserCourse classmate = new UserCourse();
+        when(userCourseRepository.findById(100L)).thenReturn(Optional.of(mockEnrollment));
+        when(userCourseRepository.findClassmates(10L, "001", "Fall 2026", 1L))
+                .thenReturn(List.of(classmate));
+
+        assertEquals(1, courseService.getClassmates(100L, EMAIL).size());
+    }
+
+    @Test
+    void getClassmates_noMatchingStudents_returnsEmptyList() {
+        stubResolveProfile();
+        when(userCourseRepository.findById(100L)).thenReturn(Optional.of(mockEnrollment));
+        when(userCourseRepository.findClassmates(10L, "001", "Fall 2026", 1L))
+                .thenReturn(List.of());
+
+        assertTrue(courseService.getClassmates(100L, EMAIL).isEmpty());
+    }
+
+    // ── searchCourses ──────────────────────────────────────────────────────────
+
+    @Test
+    void searchCourses_returnsMatchingCourses() {
+        when(courseRepository.findByCourseNameContainingIgnoreCase("biology"))
+                .thenReturn(List.of(mockCourse));
+        assertEquals(List.of(mockCourse), courseService.searchCourses("biology"));
+    }
+
+    @Test
+    void searchCourses_keywordWithNoMatches_returnsEmptyList() {
+        when(courseRepository.findByCourseNameContainingIgnoreCase("zzzzzz"))
+                .thenReturn(List.of());
+        assertTrue(courseService.searchCourses("zzzzzz").isEmpty());
+    }
+
+    @Test
+    void searchCourses_isCaseInsensitive() {
+        // repo method handles case-insensitivity — verify it's called with the raw keyword
+        courseService.searchCourses("BIOLOGY");
+        verify(courseRepository).findByCourseNameContainingIgnoreCase("BIOLOGY");
+    }
+
+    // ── getCoursesByDepartment ─────────────────────────────────────────────────
+
+    @Test
+    void getCoursesByDepartment_returnsFilteredCourses() {
+        when(courseRepository.findByDepartmentCode("CAIS")).thenReturn(List.of(mockCourse));
+        assertEquals(List.of(mockCourse), courseService.getCoursesByDepartment("CAIS"));
+    }
+
+    @Test
+    void getCoursesByDepartment_unknownDepartment_returnsEmptyList() {
+        when(courseRepository.findByDepartmentCode("FAKE")).thenReturn(List.of());
+        assertTrue(courseService.getCoursesByDepartment("FAKE").isEmpty());
+    }
+}

--- a/src/test/java/com/github/wsustudygroupapp/service/ProfileServiceTest.java
+++ b/src/test/java/com/github/wsustudygroupapp/service/ProfileServiceTest.java
@@ -1,0 +1,177 @@
+package com.github.wsustudygroupapp.service;
+
+import com.github.wsustudygroupapp.dto.ProfileRequest;
+import com.github.wsustudygroupapp.exception.ResourceNotFoundException;
+import com.github.wsustudygroupapp.model.Profile;
+import com.github.wsustudygroupapp.model.User;
+import com.github.wsustudygroupapp.repository.ProfileRepository;
+import com.github.wsustudygroupapp.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileServiceTest {
+
+    @Mock private ProfileRepository profileRepository;
+    @Mock private UserRepository userRepository;
+    @InjectMocks private ProfileService profileService;
+
+    private static final String EMAIL = "test@westfield.ma.edu";
+    private static final String UNKNOWN_EMAIL = "ghost@westfield.ma.edu";
+
+    private User mockUser;
+    private Profile mockProfile;
+
+    @BeforeEach
+    void setUp() {
+        mockUser = new User();
+        mockUser.setId(1L);
+        mockUser.setEmail(EMAIL);
+
+        mockProfile = new Profile();
+        mockProfile.setId(1L);
+        mockProfile.setUser(mockUser);
+        mockProfile.setName("Test User");
+        mockProfile.setMajor("Computer Science");
+        mockProfile.setYear("Junior");
+        mockProfile.setBio("Test bio");
+    }
+
+    // ── getProfile ────────────────────────────────────────────────────────────
+
+    @Test
+    void getProfile_userNotFound_throwsResourceNotFoundWithEmailInMessage() {
+        when(userRepository.findByEmail(UNKNOWN_EMAIL)).thenReturn(Optional.empty());
+        ResourceNotFoundException ex = assertThrows(ResourceNotFoundException.class,
+                () -> profileService.getProfile(UNKNOWN_EMAIL));
+        // error message should identify which email failed
+        assertTrue(ex.getMessage().contains(UNKNOWN_EMAIL));
+    }
+
+    @Test
+    void getProfile_userExistsButNoProfile_throwsResourceNotFoundException() {
+        // user account exists but onboarding was never completed
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(mockUser));
+        when(profileRepository.findByUserId(1L)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class,
+                () -> profileService.getProfile(EMAIL));
+    }
+
+    @Test
+    void getProfile_bothExist_returnsCorrectProfile() {
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(mockUser));
+        when(profileRepository.findByUserId(1L)).thenReturn(Optional.of(mockProfile));
+        assertEquals(mockProfile, profileService.getProfile(EMAIL));
+    }
+
+    // ── createProfile ─────────────────────────────────────────────────────────
+
+    @Test
+    void createProfile_userNotFound_throwsResourceNotFoundException() {
+        when(userRepository.findByEmail(UNKNOWN_EMAIL)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class,
+                () -> profileService.createProfile(UNKNOWN_EMAIL, new ProfileRequest()));
+    }
+
+    @Test
+    void createProfile_setsAllRequestFieldsOnNewProfile() {
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(mockUser));
+        // return the profile as-is so we can assert on its fields
+        when(profileRepository.save(any(Profile.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        ProfileRequest request = new ProfileRequest();
+        request.setName("Jane Doe");
+        request.setMajor("Biology");
+        request.setYear("Sophomore");
+        request.setBio("Loves science");
+
+        Profile result = profileService.createProfile(EMAIL, request);
+
+        assertEquals("Jane Doe", result.getName());
+        assertEquals("Biology", result.getMajor());
+        assertEquals("Sophomore", result.getYear());
+        assertEquals("Loves science", result.getBio());
+        assertEquals(mockUser, result.getUser());
+    }
+
+    @Test
+    void createProfile_linksProfileToCorrectUser() {
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(mockUser));
+        when(profileRepository.save(any(Profile.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Profile result = profileService.createProfile(EMAIL, new ProfileRequest());
+
+        // the profile must be linked to the user resolved from the email
+        assertEquals(mockUser, result.getUser());
+    }
+
+    @Test
+    void createProfile_persistsProfileExactlyOnce() {
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(mockUser));
+        when(profileRepository.save(any(Profile.class))).thenReturn(mockProfile);
+
+        profileService.createProfile(EMAIL, new ProfileRequest());
+
+        verify(profileRepository, times(1)).save(any(Profile.class));
+    }
+
+    // ── updateProfile ─────────────────────────────────────────────────────────
+
+    @Test
+    void updateProfile_userNotFound_throwsResourceNotFoundException() {
+        when(userRepository.findByEmail(UNKNOWN_EMAIL)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class,
+                () -> profileService.updateProfile(UNKNOWN_EMAIL, new ProfileRequest()));
+    }
+
+    @Test
+    void updateProfile_profileNotFound_throwsResourceNotFoundException() {
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(mockUser));
+        when(profileRepository.findByUserId(1L)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class,
+                () -> profileService.updateProfile(EMAIL, new ProfileRequest()));
+    }
+
+    @Test
+    void updateProfile_overwritesAllFourFields() {
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(mockUser));
+        when(profileRepository.findByUserId(1L)).thenReturn(Optional.of(mockProfile));
+        when(profileRepository.save(any(Profile.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        ProfileRequest request = new ProfileRequest();
+        request.setName("New Name");
+        request.setMajor("Physics");
+        request.setYear("Senior");
+        request.setBio("New bio");
+
+        Profile result = profileService.updateProfile(EMAIL, request);
+
+        assertEquals("New Name", result.getName());
+        assertEquals("Physics", result.getMajor());
+        assertEquals("Senior", result.getYear());
+        assertEquals("New bio", result.getBio());
+    }
+
+    @Test
+    void updateProfile_savesTheExistingProfileObject_notANewOne() {
+        // must update and save the existing profile, not create a new one
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(mockUser));
+        when(profileRepository.findByUserId(1L)).thenReturn(Optional.of(mockProfile));
+        when(profileRepository.save(mockProfile)).thenReturn(mockProfile);
+
+        profileService.updateProfile(EMAIL, new ProfileRequest());
+
+        // verify save is called with the exact existing profile instance
+        verify(profileRepository, times(1)).save(mockProfile);
+    }
+}


### PR DESCRIPTION
## Summary

Implemented all my sprint 1 backend tasks

<!-- What does this PR do? -->

Implements profile management and course enrollment endpoints.

Closes #<!-- issue number -->

## Changes

- 'ProfileService' - implemented getProfile, createProfile, updateProfile (resolves user by email from jwt principal)
- 'profileController' - wired GET/POST/PUT /profile endpoints, returns 200/201
- 'courseService' - implemented getAllCourses, getMyCourses, enroll, drop, getClassmates with duplicate enrollment guard (409) and ownership check on dropping courses (403). Added resolveProfile() helper
- 'courseController' - wired all enrollment endpounts + GET /courses/search?q= and GET /courses/department/{code}
- `UserCourseRepository` — added existsByProfileIdAndCourseIdAndSectionAndSemester() for duplicate enrollment check
- `ResourceNotFoundException` — new 404 exception class used across both services
- `WebSocketConfig` — borrowed Jose's broker config to unblock local app startup (to be removed/reconciled when his branch merges)

## Testing

- [✅] Existing tests pass (`./mvnw test`)
- [✅] Added tests for new behavior
- [✅] Manually tested locally

## Notes for Reviewer

JwtAuthFilter is not yet implemented, so profile/course endpoints cannot be fully tested with a real JWT token yet. should work automatically once Jose's branch merges into dev.

I realize existsByProfileIdAndCourseIdAndSectionAndSemester() is a ridiculously long method name. I plan on changing it during final cleanup.

<!-- Anything specific to look at, potential concerns, etc. -->