### PR TITLE
Feature/meeting scheduler unit testing

### DIFF
--- a/src/main/java/com/github/wsustudygroupapp/controller/MeetingSessionController.java
+++ b/src/main/java/com/github/wsustudygroupapp/controller/MeetingSessionController.java
@@ -13,6 +13,10 @@ import java.util.List;
 
 
 
+/**
+ * REST endpoints for scheduling, viewing, and cancelling study group meeting sessions.
+ * All endpoints require a valid JWT — the logged-in user's email is extracted from the token.
+ */
 @RestController
 @RequestMapping("/meetings")
 public class MeetingSessionController {
@@ -23,6 +27,7 @@ public class MeetingSessionController {
         this.meetingSessionService = meetingSessionService;
     }
 
+    /** POST /meetings — schedule a new session for a study group (201 Created). */
     @PostMapping
     public ResponseEntity<MeetingSession> scheduleSession(@RequestBody MeetingSessionRequest request,
                                                           @AuthenticationPrincipal UserDetails userDetails) {
@@ -30,18 +35,21 @@ public class MeetingSessionController {
         return ResponseEntity.status(HttpStatus.CREATED).body(session);
     }
 
+    /** GET /meetings/upcoming — returns all future sessions across the student's groups (200 OK). */
     @GetMapping("/upcoming")
     public ResponseEntity<List<MeetingSession>> getUpcomingSessions(@AuthenticationPrincipal UserDetails userDetails) {
         List<MeetingSession> sessions = meetingSessionService.getUpcomingSessions(userDetails.getUsername());
         return ResponseEntity.ok(sessions);
     }
 
+    /** GET /meetings/group/{groupId} — returns all sessions for a specific group (200 OK). */
     @GetMapping("/group/{groupId}")
     public ResponseEntity<List<MeetingSession>> getSessionsForGroup(@PathVariable Long groupId) {
         List<MeetingSession> sessions = meetingSessionService.getSessionsForGroup(groupId);
         return ResponseEntity.ok(sessions);
     }
 
+    /** DELETE /meetings/{sessionId} — cancel a session (only the creator can do this, 204 No Content). */
     @DeleteMapping("/{sessionId}")
     public ResponseEntity<Void> cancelSession(@PathVariable Long sessionId,
                                               @AuthenticationPrincipal UserDetails userDetails) {

--- a/src/main/java/com/github/wsustudygroupapp/service/MeetingSessionService.java
+++ b/src/main/java/com/github/wsustudygroupapp/service/MeetingSessionService.java
@@ -16,6 +16,10 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.List;
 
+/**
+ * Handles scheduling, retrieval, and cancellation of study group meeting sessions.
+ * When a session is created, all group members (except the creator) are notified automatically.
+ */
 @Service
 public class MeetingSessionService {
 
@@ -37,6 +41,7 @@ public class MeetingSessionService {
         this.notificationService = notificationService;
     }
 
+    /** Creates a new meeting session for a group and notifies all other members. */
     public MeetingSession scheduleSession(String schedulerEmail, MeetingSessionRequest request) {
         Profile scheduler = currentProfile(schedulerEmail);
         StudyGroup group = studyGroupRepository.findById(request.getGroupId())
@@ -58,16 +63,19 @@ public class MeetingSessionService {
         return savedSession;
     }
 
+    /** Returns all future sessions across every group the student belongs to, ordered by date. */
     public List<MeetingSession> getUpcomingSessions(String email) {
         Profile profile = currentProfile(email);
         return meetingSessionRepository.findByStudyGroupMembersIdAndScheduledAtAfterOrderByScheduledAtAsc(
                 profile.getId(), LocalDateTime.now());
     }
 
+    /** Returns all sessions for a specific group, ordered by scheduled time. Used on the group dashboard. */
     public List<MeetingSession> getSessionsForGroup(Long groupId) {
         return meetingSessionRepository.findByStudyGroupIdOrderByScheduledAtAsc(groupId);
     }
 
+    /** Deletes a session. Only the student who originally scheduled it can cancel. */
     public void cancelSession(Long sessionId, String requestingEmail) {
         Profile requester = currentProfile(requestingEmail);
         MeetingSession session = meetingSessionRepository.findById(sessionId)
@@ -80,6 +88,7 @@ public class MeetingSessionService {
         meetingSessionRepository.delete(session);
     }
 
+    // resolves the logged-in user's Profile from their email — throws 404 if not found
     private Profile currentProfile(String email) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found: " + email));

--- a/src/test/java/com/github/wsustudygroupapp/controller/MeetingSessionControllerTest.java
+++ b/src/test/java/com/github/wsustudygroupapp/controller/MeetingSessionControllerTest.java
@@ -1,0 +1,156 @@
+package com.github.wsustudygroupapp.controller;
+
+import com.github.wsustudygroupapp.dto.MeetingSessionRequest;
+import com.github.wsustudygroupapp.exception.ResourceNotFoundException;
+import com.github.wsustudygroupapp.model.MeetingSession;
+import com.github.wsustudygroupapp.service.MeetingSessionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingSessionControllerTest {
+
+    @Mock private MeetingSessionService meetingSessionService;
+    @Mock private UserDetails userDetails;
+    @InjectMocks private MeetingSessionController meetingSessionController;
+
+    private static final String EMAIL = "test@westfield.ma.edu";
+    private MeetingSession mockSession;
+    private MeetingSessionRequest sessionRequest;
+
+    @BeforeEach
+    void setUp() {
+        mockSession = new MeetingSession();
+        mockSession.setId(10L);
+        mockSession.setScheduledAt(LocalDateTime.of(2026, 5, 10, 14, 0));
+        mockSession.setLocation("Ely Library Rm 204");
+        mockSession.setNotes("Review chapters 5-7");
+
+        sessionRequest = new MeetingSessionRequest();
+        sessionRequest.setGroupId(5L);
+        sessionRequest.setScheduledAt(LocalDateTime.of(2026, 5, 10, 14, 0));
+        sessionRequest.setLocation("Ely Library Rm 204");
+        sessionRequest.setNotes("Review chapters 5-7");
+    }
+
+    // stubs userDetails.getUsername() — called per-test to avoid UnnecessaryStubbingException
+    private void mockAuth() {
+        when(userDetails.getUsername()).thenReturn(EMAIL);
+    }
+
+    // ── POST /meetings ────────────────────────────────────────────────────────
+
+    @Test
+    void scheduleSession_returns201WithCreatedSession() {
+        mockAuth();
+        when(meetingSessionService.scheduleSession(EMAIL, sessionRequest)).thenReturn(mockSession);
+
+        ResponseEntity<MeetingSession> response = meetingSessionController.scheduleSession(sessionRequest, userDetails);
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertEquals(mockSession, response.getBody());
+    }
+
+    @Test
+    void scheduleSession_serviceThrowsNotFound_propagates() {
+        mockAuth();
+        when(meetingSessionService.scheduleSession(EMAIL, sessionRequest))
+                .thenThrow(new ResourceNotFoundException("Study group not found: 5"));
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> meetingSessionController.scheduleSession(sessionRequest, userDetails));
+    }
+
+    // ── GET /meetings/upcoming ────────────────────────────────────────────────
+
+    @Test
+    void getUpcomingSessions_returns200WithSessionList() {
+        mockAuth();
+        when(meetingSessionService.getUpcomingSessions(EMAIL)).thenReturn(List.of(mockSession));
+
+        ResponseEntity<List<MeetingSession>> response = meetingSessionController.getUpcomingSessions(userDetails);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1, response.getBody().size());
+    }
+
+    @Test
+    void getUpcomingSessions_noUpcoming_returns200WithEmptyList() {
+        mockAuth();
+        when(meetingSessionService.getUpcomingSessions(EMAIL)).thenReturn(List.of());
+
+        ResponseEntity<List<MeetingSession>> response = meetingSessionController.getUpcomingSessions(userDetails);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody().isEmpty());
+    }
+
+    // ── GET /meetings/group/{groupId} ─────────────────────────────────────────
+
+    @Test
+    void getSessionsForGroup_returns200WithSessionList() {
+        when(meetingSessionService.getSessionsForGroup(5L)).thenReturn(List.of(mockSession));
+
+        ResponseEntity<List<MeetingSession>> response = meetingSessionController.getSessionsForGroup(5L);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1, response.getBody().size());
+    }
+
+    @Test
+    void getSessionsForGroup_noSessions_returns200WithEmptyList() {
+        when(meetingSessionService.getSessionsForGroup(5L)).thenReturn(List.of());
+
+        ResponseEntity<List<MeetingSession>> response = meetingSessionController.getSessionsForGroup(5L);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody().isEmpty());
+    }
+
+    // ── DELETE /meetings/{sessionId} ───────────────────────��──────────────────
+
+    @Test
+    void cancelSession_returns204NoContent() {
+        mockAuth();
+        doNothing().when(meetingSessionService).cancelSession(10L, EMAIL);
+
+        ResponseEntity<Void> response = meetingSessionController.cancelSession(10L, userDetails);
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+    }
+
+    @Test
+    void cancelSession_sessionNotFound_propagates() {
+        mockAuth();
+        doThrow(new ResourceNotFoundException("Meeting session not found: 10"))
+                .when(meetingSessionService).cancelSession(10L, EMAIL);
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> meetingSessionController.cancelSession(10L, userDetails));
+    }
+
+    @Test
+    void cancelSession_notTheCreator_propagatesIllegalArgument() {
+        mockAuth();
+        doThrow(new IllegalArgumentException("Only the session creator can cancel it"))
+                .when(meetingSessionService).cancelSession(10L, EMAIL);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> meetingSessionController.cancelSession(10L, userDetails));
+    }
+}

--- a/src/test/java/com/github/wsustudygroupapp/controller/MeetingSessionControllerTest.java
+++ b/src/test/java/com/github/wsustudygroupapp/controller/MeetingSessionControllerTest.java
@@ -18,8 +18,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/com/github/wsustudygroupapp/service/MeetingSessionServiceTest.java
+++ b/src/test/java/com/github/wsustudygroupapp/service/MeetingSessionServiceTest.java
@@ -1,0 +1,239 @@
+package com.github.wsustudygroupapp.service;
+
+import com.github.wsustudygroupapp.dto.MeetingSessionRequest;
+import com.github.wsustudygroupapp.exception.ResourceNotFoundException;
+import com.github.wsustudygroupapp.model.MeetingSession;
+import com.github.wsustudygroupapp.model.Profile;
+import com.github.wsustudygroupapp.model.StudyGroup;
+import com.github.wsustudygroupapp.model.User;
+import com.github.wsustudygroupapp.repository.MeetingSessionRepository;
+import com.github.wsustudygroupapp.repository.ProfileRepository;
+import com.github.wsustudygroupapp.repository.StudyGroupRepository;
+import com.github.wsustudygroupapp.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingSessionServiceTest {
+
+    @Mock private MeetingSessionRepository meetingSessionRepository;
+    @Mock private StudyGroupRepository studyGroupRepository;
+    @Mock private ProfileRepository profileRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private NotificationService notificationService;
+    @InjectMocks private MeetingSessionService meetingSessionService;
+
+    private static final String EMAIL = "test@westfield.ma.edu";
+    private static final String UNKNOWN_EMAIL = "ghost@westfield.ma.edu";
+
+    private User mockUser;
+    private Profile mockProfile;
+    private Profile otherProfile;
+    private StudyGroup mockGroup;
+    private MeetingSession mockSession;
+    private MeetingSessionRequest sessionRequest;
+
+    @BeforeEach
+    void setUp() {
+        mockUser = new User();
+        mockUser.setId(1L);
+        mockUser.setEmail(EMAIL);
+
+        mockProfile = new Profile();
+        mockProfile.setId(1L);
+        mockProfile.setUser(mockUser);
+
+        otherProfile = new Profile();
+        otherProfile.setId(99L);
+
+        mockGroup = new StudyGroup();
+        mockGroup.setId(5L);
+        mockGroup.setName("Algorithms Study Group");
+        mockGroup.setMembers(List.of(mockProfile, otherProfile));
+
+        mockSession = new MeetingSession();
+        mockSession.setId(10L);
+        mockSession.setStudyGroup(mockGroup);
+        mockSession.setScheduledBy(mockProfile);
+        mockSession.setScheduledAt(LocalDateTime.of(2026, 5, 10, 14, 0));
+        mockSession.setLocation("Ely Library Rm 204");
+        mockSession.setNotes("Review chapters 5-7");
+
+        sessionRequest = new MeetingSessionRequest();
+        sessionRequest.setGroupId(5L);
+        sessionRequest.setScheduledAt(LocalDateTime.of(2026, 5, 10, 14, 0));
+        sessionRequest.setLocation("Ely Library Rm 204");
+        sessionRequest.setNotes("Review chapters 5-7");
+    }
+
+    // stubs the currentProfile() helper used by most service methods
+    private void stubCurrentProfile() {
+        when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(mockUser));
+        when(profileRepository.findByUserId(1L)).thenReturn(Optional.of(mockProfile));
+    }
+
+    // ── scheduleSession ───────────────────────────────────────────────────────
+
+    @Test
+    void scheduleSession_userNotFound_throwsResourceNotFoundException() {
+        when(userRepository.findByEmail(UNKNOWN_EMAIL)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class,
+                () -> meetingSessionService.scheduleSession(UNKNOWN_EMAIL, sessionRequest));
+    }
+
+    @Test
+    void scheduleSession_groupNotFound_throwsResourceNotFoundException() {
+        stubCurrentProfile();
+        when(studyGroupRepository.findById(5L)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class,
+                () -> meetingSessionService.scheduleSession(EMAIL, sessionRequest));
+    }
+
+    @Test
+    void scheduleSession_setsAllFieldsOnNewSession() {
+        stubCurrentProfile();
+        when(studyGroupRepository.findById(5L)).thenReturn(Optional.of(mockGroup));
+        when(meetingSessionRepository.save(any(MeetingSession.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        MeetingSession result = meetingSessionService.scheduleSession(EMAIL, sessionRequest);
+
+        assertEquals(mockGroup, result.getStudyGroup());
+        assertEquals(mockProfile, result.getScheduledBy());
+        assertEquals(sessionRequest.getScheduledAt(), result.getScheduledAt());
+        assertEquals("Ely Library Rm 204", result.getLocation());
+        assertEquals("Review chapters 5-7", result.getNotes());
+    }
+
+    @Test
+    void scheduleSession_persistsSessionExactlyOnce() {
+        stubCurrentProfile();
+        when(studyGroupRepository.findById(5L)).thenReturn(Optional.of(mockGroup));
+        when(meetingSessionRepository.save(any(MeetingSession.class))).thenReturn(mockSession);
+
+        meetingSessionService.scheduleSession(EMAIL, sessionRequest);
+
+        verify(meetingSessionRepository, times(1)).save(any(MeetingSession.class));
+    }
+
+    @Test
+    void scheduleSession_notifiesGroupMembers() {
+        stubCurrentProfile();
+        when(studyGroupRepository.findById(5L)).thenReturn(Optional.of(mockGroup));
+        when(meetingSessionRepository.save(any(MeetingSession.class))).thenReturn(mockSession);
+
+        meetingSessionService.scheduleSession(EMAIL, sessionRequest);
+
+        verify(notificationService, times(1)).notifyGroupMembers(eq(mockGroup), anyString(), any(), eq(10L), eq(1L));
+    }
+
+    // ── getUpcomingSessions ───────────────────────────────────────────────────
+
+    @Test
+    void getUpcomingSessions_userNotFound_throwsResourceNotFoundException() {
+        when(userRepository.findByEmail(UNKNOWN_EMAIL)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class,
+                () -> meetingSessionService.getUpcomingSessions(UNKNOWN_EMAIL));
+    }
+
+    @Test
+    void getUpcomingSessions_returnsSessionsFromRepo() {
+        stubCurrentProfile();
+        when(meetingSessionRepository.findByStudyGroupMembersIdAndScheduledAtAfterOrderByScheduledAtAsc(
+                eq(1L), any(LocalDateTime.class))).thenReturn(List.of(mockSession));
+
+        List<MeetingSession> result = meetingSessionService.getUpcomingSessions(EMAIL);
+
+        assertEquals(1, result.size());
+        assertEquals(mockSession, result.get(0));
+    }
+
+    @Test
+    void getUpcomingSessions_noUpcoming_returnsEmptyList() {
+        stubCurrentProfile();
+        when(meetingSessionRepository.findByStudyGroupMembersIdAndScheduledAtAfterOrderByScheduledAtAsc(
+                eq(1L), any(LocalDateTime.class))).thenReturn(List.of());
+
+        assertTrue(meetingSessionService.getUpcomingSessions(EMAIL).isEmpty());
+    }
+
+    // ── getSessionsForGroup ───────────────────────────────────────────────────
+
+    @Test
+    void getSessionsForGroup_returnsSessionsOrderedByTime() {
+        when(meetingSessionRepository.findByStudyGroupIdOrderByScheduledAtAsc(5L))
+                .thenReturn(List.of(mockSession));
+
+        List<MeetingSession> result = meetingSessionService.getSessionsForGroup(5L);
+
+        assertEquals(1, result.size());
+        assertEquals(mockSession, result.get(0));
+    }
+
+    @Test
+    void getSessionsForGroup_noSessions_returnsEmptyList() {
+        when(meetingSessionRepository.findByStudyGroupIdOrderByScheduledAtAsc(5L))
+                .thenReturn(List.of());
+
+        assertTrue(meetingSessionService.getSessionsForGroup(5L).isEmpty());
+    }
+
+    // ── cancelSession ─────────────────────────────────────────────────────────
+
+    @Test
+    void cancelSession_userNotFound_throwsResourceNotFoundException() {
+        when(userRepository.findByEmail(UNKNOWN_EMAIL)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class,
+                () -> meetingSessionService.cancelSession(10L, UNKNOWN_EMAIL));
+    }
+
+    @Test
+    void cancelSession_sessionNotFound_throwsResourceNotFoundException() {
+        stubCurrentProfile();
+        when(meetingSessionRepository.findById(10L)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class,
+                () -> meetingSessionService.cancelSession(10L, EMAIL));
+    }
+
+    @Test
+    void cancelSession_notTheCreator_throwsIllegalArgumentException() {
+        stubCurrentProfile();
+        mockSession.setScheduledBy(otherProfile);
+        when(meetingSessionRepository.findById(10L)).thenReturn(Optional.of(mockSession));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> meetingSessionService.cancelSession(10L, EMAIL));
+    }
+
+    @Test
+    void cancelSession_notTheCreator_doesNotDelete() {
+        stubCurrentProfile();
+        mockSession.setScheduledBy(otherProfile);
+        when(meetingSessionRepository.findById(10L)).thenReturn(Optional.of(mockSession));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> meetingSessionService.cancelSession(10L, EMAIL));
+        verify(meetingSessionRepository, never()).delete(any());
+    }
+
+    @Test
+    void cancelSession_ownSession_deletesCorrectRecord() {
+        stubCurrentProfile();
+        when(meetingSessionRepository.findById(10L)).thenReturn(Optional.of(mockSession));
+
+        meetingSessionService.cancelSession(10L, EMAIL);
+
+        verify(meetingSessionRepository, times(1)).delete(mockSession);
+    }
+}


### PR DESCRIPTION
## Summary

Added unit tests and javadoc comments for the meeting scheduler feature (MeetingSessionService and MeetingSessionController) that Jose implemented. 

## Changes

- Added 15 unit tests for MeetingSessionService (schedule, getUpcoming, getSessionsForGroup, and cancel).
- Added 9 unit tests for MeetingSessionController (status codes, error propagation).
- Added javadoc commets to MeetingSessionService and MeetingSessionController.

## Testing

- [x] Existing tests pass (`./mvnw test`)
- [x] Added tests for new behavior
- [x] Manually tested locally

## Notes for Reviewer

No logic changes, only tests and comments added to the existing meeting scheduler code.