### PR TITLE
Feature/badge system

### DIFF
--- a/frontend/src/components/AppHeader.jsx
+++ b/frontend/src/components/AppHeader.jsx
@@ -35,8 +35,8 @@ function formatEventDate(isoStr) {
 }
 
 function AppHeader() {
-    const { profile, logout }    = useAuth()
-    const { theme, toggleTheme } = useTheme()
+    const { profile, logout }          = useAuth()
+    const { theme, toggleTheme }       = useTheme()
     const { getUpcoming, removeEvent } = useEvents()
     const location  = useLocation()
     const navigate  = useNavigate()

--- a/frontend/src/components/AppHeader.jsx
+++ b/frontend/src/components/AppHeader.jsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
 import { useTheme } from '../context/ThemeContext'
 import { useEvents } from '../context/EventsContext'
+import { useToast } from '../context/ToastContext'
 import OwlLogo from './OwlLogo'
 
 function SunIcon() {
@@ -38,6 +39,17 @@ function AppHeader() {
     const { profile, logout }          = useAuth()
     const { theme, toggleTheme }       = useTheme()
     const { getUpcoming, removeEvent } = useEvents()
+    const { addToast }                 = useToast()
+
+    const handleThemeToggle = () => {
+        toggleTheme()
+        addToast({
+            title: theme === 'light' ? 'Dark mode enabled' : 'Light mode enabled',
+            description: theme === 'light' ? 'Easy on the eyes.' : 'Welcome back to the light.',
+            type: 'system',
+            duration: 2500,
+        })
+    }
     const location  = useLocation()
     const navigate  = useNavigate()
 
@@ -112,7 +124,7 @@ function AppHeader() {
 
                     {/* Theme toggle */}
                     <button
-                        onClick={toggleTheme}
+                        onClick={handleThemeToggle}
                         className="p-2 rounded-lg text-wsu-slate dark:text-gray-300 hover:bg-wsu-mist dark:hover:bg-gray-800 transition-colors"
                         aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
                     >
@@ -260,7 +272,7 @@ function AppHeader() {
                     ))}
                     <div className="pt-2 border-t border-gray-100 dark:border-gray-700 mt-2">
                         <button
-                            onClick={toggleTheme}
+                            onClick={handleThemeToggle}
                             className="flex items-center gap-2 w-full px-4 py-2.5 rounded-xl text-sm font-semibold text-wsu-slate dark:text-gray-300 hover:bg-wsu-mist dark:hover:bg-gray-800 transition-colors"
                         >
                             {theme === 'dark' ? <SunIcon /> : <MoonIcon />}

--- a/frontend/src/components/BadgeIcon.jsx
+++ b/frontend/src/components/BadgeIcon.jsx
@@ -1,0 +1,190 @@
+import { useId } from 'react'
+
+function toRoman(n) {
+  if (n >= 5000) return 'V̄'
+  const vals = [1000,900,500,400,100,90,50,40,10,9,5,4,1]
+  const syms = ['M','CM','D','CD','C','XC','L','XL','X','IX','V','IV','I']
+  let r = ''
+  for (let i = 0; i < vals.length; i++) {
+    while (n >= vals[i]) { r += syms[i]; n -= vals[i] }
+  }
+  return r
+}
+
+// Shape = category identity. Each category always renders the same shape.
+const CATEGORY_SHAPE = {
+  logins:   'shield',
+  streak:   'flame',
+  messages: 'bubble',
+  emojis:   'circle',
+  groups:   'hexagon',
+  sessions: 'book',
+  points:   'trophy',
+  helper:   'heart',
+}
+
+// Outer path = visible frame/border. Inner path = recessed face.
+// All coordinates within a 40×40 viewBox.
+const SHAPES = {
+  // logins — classic downward shield
+  shield: {
+    outer: 'M3,3 L37,3 L37,22 L20,37 L3,22 Z',
+    inner: 'M7,7 L33,7 L33,21 L20,32 L7,21 Z',
+    textY: 19,
+  },
+  // streak — teardrop flame (narrow tip at top, full at bottom)
+  flame: {
+    outer: 'M20,2 C14,4 4,12 6,22 C8,32 14,38 20,38 C26,38 32,32 34,22 C36,12 26,4 20,2 Z',
+    inner: 'M20,7 C15,9 8,16 10,22 C12,30 16,34 20,34 C24,34 28,30 30,22 C32,16 25,9 20,7 Z',
+    textY: 23,
+  },
+  // messages — speech bubble with tail at bottom-center
+  bubble: {
+    outer: 'M8,2 Q2,2 2,8 L2,24 Q2,30 8,30 L15,30 L20,38 L25,30 L32,30 Q38,30 38,24 L38,8 Q38,2 32,2 Z',
+    inner: 'M10,6 Q6,6 6,10 L6,22 Q6,26 10,26 L16,26 L20,32 L24,26 L30,26 Q34,26 34,22 L34,10 Q34,6 30,6 Z',
+    textY: 16,
+  },
+  // emojis — circle (represents a face)
+  circle: {
+    isCircle: true,
+    outerR: 18,
+    innerR: 13,
+    textY: 21,
+  },
+  // groups — hexagon (network/hive)
+  hexagon: {
+    outer: 'M10,2 L30,2 L38,20 L30,38 L10,38 L2,20 Z',
+    inner: 'M13,7 L27,7 L33,20 L27,33 L13,33 L7,20 Z',
+    textY: 21,
+  },
+  // sessions — open book (two pages meeting at a spine)
+  book: {
+    outer: 'M2,8 Q2,4 6,4 L19,6 L20,8 L21,6 L34,4 Q38,4 38,8 L38,34 Q38,36 34,36 L21,34 L20,36 L19,34 L6,36 Q2,36 2,34 Z',
+    inner: 'M5,11 Q5,8 8,8 L19,10 L20,12 L21,10 L32,8 Q35,8 35,11 L35,31 Q35,34 32,34 L21,32 L20,34 L19,32 L8,34 Q5,34 5,31 Z',
+    textY: 22,
+  },
+  // points — trophy cup with base (two subpaths)
+  trophy: {
+    outer: 'M8,2 L32,2 L32,20 Q32,30 20,32 Q8,30 8,20 Z M14,32 L26,32 L28,38 L12,38 Z',
+    inner: 'M11,5 L29,5 L29,19 Q29,27 20,29 Q11,27 11,19 Z M15,29 L25,29 L27,35 L13,35 Z',
+    textY: 15,
+  },
+  // helper — heart
+  heart: {
+    outer: 'M20,34 C10,27 2,20 2,12 Q2,2 12,4 Q16,4 20,10 Q24,4 28,4 Q38,2 38,12 C38,20 30,27 20,34 Z',
+    inner: 'M20,29 C12,23 6,18 6,12 Q6,7 13,8 Q16,8 20,13 Q24,8 27,8 Q34,7 34,12 C34,18 28,23 20,29 Z',
+    textY: 19,
+  },
+}
+
+// Colors match leaderboard rank tiers exactly:
+// 1=Hatchling(gray) 2=Fledgling(green) 3=NightOwl(blue) 4=NestGuardian(purple) 5=WiseOwl(gold)
+// Face is white→tinted-edge gradient so numerals stay readable on a bright background.
+const TIER_COLORS = {
+  1: { frameLight: '#e2e8f0', frameMid: '#94a3b8', frameDark: '#475569', faceCenter: '#f8fafc', faceEdge: '#e2e8f0', numColor: '#334155' },
+  2: { frameLight: '#bbf7d0', frameMid: '#4ade80', frameDark: '#15803d', faceCenter: '#f0fdf4', faceEdge: '#bbf7d0', numColor: '#14532d' },
+  3: { frameLight: '#bfdbfe', frameMid: '#60a5fa', frameDark: '#1d4ed8', faceCenter: '#eff6ff', faceEdge: '#bfdbfe', numColor: '#1e3a8a' },
+  4: { frameLight: '#e9d5ff', frameMid: '#c084fc', frameDark: '#7e22ce', faceCenter: '#faf5ff', faceEdge: '#e9d5ff', numColor: '#581c87' },
+  5: { frameLight: '#fef08a', frameMid: '#fbbf24', frameDark: '#b45309', faceCenter: '#fffbeb', faceEdge: '#fef08a', numColor: '#92400e' },
+}
+
+const SIZE_CLASSES = { sm: 'w-8 h-8', md: 'w-10 h-10', lg: 'w-14 h-14' }
+
+export default function BadgeIcon({ badge, size = 'md', showTooltip = true }) {
+  const uid  = useId().replace(/:/g, '')
+  if (!badge) return null
+
+  const colors    = TIER_COLORS[badge.tier] ?? TIER_COLORS[1]
+  const shapeName = CATEGORY_SHAPE[badge.category] ?? 'shield'
+  const shape     = SHAPES[shapeName]
+  const roman     = toRoman(badge.tier ?? 1)
+  const visLen    = roman.replace(/̄/g, '').length
+  const fontSize  = visLen <= 1 ? 16 : visLen <= 2 ? 13 : visLen <= 3 ? 10 : 8
+
+  const frameGradId  = `fg${uid}`
+  const highlightId  = `hi${uid}`
+  const faceGradId   = `rg${uid}`
+  const shadowId     = `sh${uid}`
+
+  return (
+    <div className={`relative group inline-flex flex-shrink-0 overflow-visible ${SIZE_CLASSES[size] ?? SIZE_CLASSES.md}`}>
+      <svg viewBox="0 0 40 40" className="w-full h-full overflow-visible">
+        <defs>
+          {/* Metallic frame gradient — diagonal, lighter top-left to darker bottom-right */}
+          <linearGradient id={frameGradId} x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%"   stopColor={colors.frameLight} />
+            <stop offset="45%"  stopColor={colors.frameMid}   />
+            <stop offset="100%" stopColor={colors.frameDark}  />
+          </linearGradient>
+
+          {/* Highlight shimmer — white top-left, dark bottom-right */}
+          <linearGradient id={highlightId} x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%"   stopColor="white" stopOpacity="0.45" />
+            <stop offset="45%"  stopColor="white" stopOpacity="0"    />
+            <stop offset="100%" stopColor="black" stopOpacity="0.25" />
+          </linearGradient>
+
+          {/* Face gradient — bright white center fading to a light tier-tinted edge */}
+          <radialGradient id={faceGradId} cx="38%" cy="32%" r="75%">
+            <stop offset="0%"   stopColor={colors.faceCenter} stopOpacity="1"   />
+            <stop offset="70%"  stopColor={colors.faceCenter} stopOpacity="0.95" />
+            <stop offset="100%" stopColor={colors.faceEdge}   stopOpacity="1"   />
+          </radialGradient>
+
+          {/* Drop shadow filter */}
+          <filter id={shadowId} x="-30%" y="-30%" width="160%" height="160%">
+            <feDropShadow dx="1" dy="2" stdDeviation="2.5" floodColor="rgba(0,0,0,0.6)" />
+          </filter>
+        </defs>
+
+        <g filter={`url(#${shadowId})`}>
+          {shape.isCircle ? (
+            <>
+              <circle cx="20" cy="20" r={shape.outerR} fill={`url(#${frameGradId})`} />
+              <circle cx="20" cy="20" r={shape.outerR} fill={`url(#${highlightId})`} />
+              <circle cx="20" cy="20" r={shape.innerR} fill={`url(#${faceGradId})`} />
+            </>
+          ) : (
+            <>
+              <path d={shape.outer} fill={`url(#${frameGradId})`} />
+              <path d={shape.outer} fill={`url(#${highlightId})`} />
+              <path d={shape.inner} fill={`url(#${faceGradId})`} />
+            </>
+          )}
+
+          {/* Roman numeral — black fill, colored stroke outline */}
+          <text
+            x="20"
+            y={shape.textY}
+            textAnchor="middle"
+            dominantBaseline="central"
+            fontSize={fontSize}
+            fontWeight="bold"
+            fontFamily="Georgia, 'Times New Roman', serif"
+            fill={colors.numColor}
+            stroke="white"
+            strokeWidth="0.5"
+            paintOrder="stroke fill"
+          >
+            {roman}
+          </text>
+        </g>
+      </svg>
+
+      {showTooltip && (
+        <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-50 pointer-events-none
+                        hidden group-hover:block w-max max-w-[160px]
+                        bg-gray-900 dark:bg-gray-800 text-white text-xs rounded-xl
+                        px-3 py-2 text-center shadow-xl">
+          <p className="font-semibold leading-snug">{badge.name}</p>
+          <p className="text-gray-300 text-[10px] mt-0.5 leading-snug">{badge.description}</p>
+          {badge.earnedAt && (
+            <p className="text-gray-400 text-[10px] mt-1">
+              {new Date(badge.earnedAt).toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' })}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/BadgeIcon.jsx
+++ b/frontend/src/components/BadgeIcon.jsx
@@ -77,15 +77,16 @@ const SHAPES = {
   },
 }
 
-// Colors match leaderboard rank tiers exactly:
-// 1=Hatchling(gray) 2=Fledgling(green) 3=NightOwl(blue) 4=NestGuardian(purple) 5=WiseOwl(gold)
-// Face is white→tinted-edge gradient so numerals stay readable on a bright background.
+// Badge tier colors — independent achievement progression, not tied to leaderboard ranks.
+// 1=Bronze · 2=Silver · 3=Gold · 4=Emerald · 5=Amethyst
+// Badge tier colors — independent achievement progression, not tied to leaderboard ranks.
+// 1=Bronze · 2=Silver · 3=Gold · 4=Emerald · 5=Amethyst
 const TIER_COLORS = {
-  1: { frameLight: '#e2e8f0', frameMid: '#94a3b8', frameDark: '#475569', faceCenter: '#f8fafc', faceEdge: '#e2e8f0', numColor: '#334155' },
-  2: { frameLight: '#bbf7d0', frameMid: '#4ade80', frameDark: '#15803d', faceCenter: '#f0fdf4', faceEdge: '#bbf7d0', numColor: '#14532d' },
-  3: { frameLight: '#bfdbfe', frameMid: '#60a5fa', frameDark: '#1d4ed8', faceCenter: '#eff6ff', faceEdge: '#bfdbfe', numColor: '#1e3a8a' },
-  4: { frameLight: '#e9d5ff', frameMid: '#c084fc', frameDark: '#7e22ce', faceCenter: '#faf5ff', faceEdge: '#e9d5ff', numColor: '#581c87' },
-  5: { frameLight: '#fef08a', frameMid: '#fbbf24', frameDark: '#b45309', faceCenter: '#fffbeb', faceEdge: '#fef08a', numColor: '#92400e' },
+  1: { frameLight: '#f5a44c', frameMid: '#d4641a', frameDark: '#8b3a08', faceCenter: '#fff5e8', faceEdge: '#ffd4a0', numColor: '#7a2e06' },
+  2: { frameLight: '#d0e4f8', frameMid: '#7898c0', frameDark: '#3a5878', faceCenter: '#f0f6ff', faceEdge: '#b8d0ec', numColor: '#2e4868' },
+  3: { frameLight: '#ffe040', frameMid: '#f0aa00', frameDark: '#a07000', faceCenter: '#fffce0', faceEdge: '#ffe880', numColor: '#785000' },
+  4: { frameLight: '#3aeaa0', frameMid: '#00b860', frameDark: '#006838', faceCenter: '#e8ffee', faceEdge: '#80ffb8', numColor: '#005030' },
+  5: { frameLight: '#cc66ff', frameMid: '#9900ee', frameDark: '#5a0090', faceCenter: '#f8e8ff', faceEdge: '#e0a0ff', numColor: '#6600a0' },
 }
 
 const SIZE_CLASSES = { sm: 'w-8 h-8', md: 'w-10 h-10', lg: 'w-14 h-14' }

--- a/frontend/src/components/ToastContainer.jsx
+++ b/frontend/src/components/ToastContainer.jsx
@@ -1,0 +1,62 @@
+const TYPE_STYLES = {
+  info:    { bar: 'bg-blue-600',   iconBg: 'bg-blue-50   dark:bg-blue-900/40',   iconColor: 'text-blue-600   dark:text-blue-400',   icon: 'ℹ' },
+  success: { bar: 'bg-green-500',  iconBg: 'bg-green-50  dark:bg-green-900/40',  iconColor: 'text-green-600  dark:text-green-400',  icon: '✓' },
+  badge:   { bar: 'bg-amber-400',  iconBg: 'bg-amber-50  dark:bg-amber-900/40',  iconColor: 'text-amber-600  dark:text-amber-400',  icon: '🏅' },
+  warning: { bar: 'bg-orange-400', iconBg: 'bg-orange-50 dark:bg-orange-900/40', iconColor: 'text-orange-600 dark:text-orange-400', icon: '⚠' },
+  error:   { bar: 'bg-red-500',    iconBg: 'bg-red-50    dark:bg-red-900/40',    iconColor: 'text-red-600    dark:text-red-400',    icon: '✕' },
+}
+
+function Toast({ toast, onDismiss }) {
+  const s = TYPE_STYLES[toast.type] ?? TYPE_STYLES.info
+
+  return (
+    <div
+      className={`flex items-start gap-3 bg-white dark:bg-gray-900 rounded-2xl shadow-xl
+                  border border-gray-100 dark:border-gray-700 pl-1 pr-4 py-3 w-80
+                  transition-all duration-300 ease-in-out
+                  ${toast.removing ? 'opacity-0 translate-x-8 scale-95' : 'opacity-100 translate-x-0 scale-100 animate-fade-in'}`}
+    >
+      {/* Colored left bar */}
+      <div className={`w-1 self-stretch rounded-full flex-shrink-0 ${s.bar}`} />
+
+      {/* Icon */}
+      <div className={`w-8 h-8 rounded-xl flex items-center justify-center text-sm font-bold flex-shrink-0 ${s.iconBg} ${s.iconColor}`}>
+        {s.icon}
+      </div>
+
+      {/* Text */}
+      <div className="flex-1 min-w-0 pt-0.5">
+        <p className="text-sm font-semibold text-wsu-navy dark:text-white leading-snug">
+          {toast.title}
+        </p>
+        {toast.description && (
+          <p className="text-xs text-wsu-slate dark:text-gray-400 mt-0.5 leading-snug">
+            {toast.description}
+          </p>
+        )}
+      </div>
+
+      {/* Dismiss */}
+      <button
+        onClick={() => onDismiss(toast.id)}
+        className="text-gray-300 dark:text-gray-600 hover:text-gray-500 dark:hover:text-gray-400 text-xl leading-none flex-shrink-0 transition-colors mt-0.5"
+        aria-label="Dismiss"
+      >
+        ×
+      </button>
+    </div>
+  )
+}
+
+export default function ToastContainer({ toasts, onDismiss }) {
+  if (toasts.length === 0) return null
+  return (
+    <div className="fixed bottom-6 right-6 z-[100] flex flex-col gap-3 pointer-events-none">
+      {toasts.map(toast => (
+        <div key={toast.id} className="pointer-events-auto">
+          <Toast toast={toast} onDismiss={onDismiss} />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/ToastContainer.jsx
+++ b/frontend/src/components/ToastContainer.jsx
@@ -1,28 +1,37 @@
 const TYPE_STYLES = {
-  info:    { bar: 'bg-blue-600',   iconBg: 'bg-blue-50   dark:bg-blue-900/40',   iconColor: 'text-blue-600   dark:text-blue-400',   icon: 'ℹ' },
-  success: { bar: 'bg-green-500',  iconBg: 'bg-green-50  dark:bg-green-900/40',  iconColor: 'text-green-600  dark:text-green-400',  icon: '✓' },
+  system:  { bar: null,            iconBg: null,                                    iconColor: null,                                    icon: null  },
+  info:    { bar: 'bg-blue-600',   iconBg: 'bg-blue-50   dark:bg-blue-900/40',   iconColor: 'text-blue-600   dark:text-blue-400',   icon: 'ℹ'  },
+  success: { bar: 'bg-green-500',  iconBg: 'bg-green-50  dark:bg-green-900/40',  iconColor: 'text-green-600  dark:text-green-400',  icon: '✓'  },
   badge:   { bar: 'bg-amber-400',  iconBg: 'bg-amber-50  dark:bg-amber-900/40',  iconColor: 'text-amber-600  dark:text-amber-400',  icon: '🏅' },
-  warning: { bar: 'bg-orange-400', iconBg: 'bg-orange-50 dark:bg-orange-900/40', iconColor: 'text-orange-600 dark:text-orange-400', icon: '⚠' },
-  error:   { bar: 'bg-red-500',    iconBg: 'bg-red-50    dark:bg-red-900/40',    iconColor: 'text-red-600    dark:text-red-400',    icon: '✕' },
+  warning: { bar: 'bg-orange-400', iconBg: 'bg-orange-50 dark:bg-orange-900/40', iconColor: 'text-orange-600 dark:text-orange-400', icon: '⚠'  },
+  error:   { bar: 'bg-red-500',    iconBg: 'bg-red-50    dark:bg-red-900/40',    iconColor: 'text-red-600    dark:text-red-400',    icon: '✕'  },
 }
 
 function Toast({ toast, onDismiss }) {
-  const s = TYPE_STYLES[toast.type] ?? TYPE_STYLES.info
+  const s      = TYPE_STYLES[toast.type] ?? TYPE_STYLES.info
+  const isSystem = toast.type === 'system'
 
   return (
     <div
       className={`flex items-start gap-3 bg-white dark:bg-gray-900 rounded-2xl shadow-xl
-                  border border-gray-100 dark:border-gray-700 pl-1 pr-4 py-3 w-80
-                  transition-all duration-300 ease-in-out
-                  ${toast.removing ? 'opacity-0 translate-x-8 scale-95' : 'opacity-100 translate-x-0 scale-100 animate-fade-in'}`}
+                  border-2 border-blue-700
+                  pr-4 py-3 w-80
+                  ${isSystem ? 'px-4' : 'pl-1'}
+                  ${toast.removing
+                    ? 'opacity-0 transition-opacity duration-500 ease-in'
+                    : 'animate-toast-in'}`}
     >
-      {/* Colored left bar */}
-      <div className={`w-1 self-stretch rounded-full flex-shrink-0 ${s.bar}`} />
+      {/* Colored left bar — hidden for system toasts */}
+      {!isSystem && s.bar && (
+        <div className={`w-1 self-stretch rounded-full flex-shrink-0 ${s.bar}`} />
+      )}
 
-      {/* Icon */}
-      <div className={`w-8 h-8 rounded-xl flex items-center justify-center text-sm font-bold flex-shrink-0 ${s.iconBg} ${s.iconColor}`}>
-        {s.icon}
-      </div>
+      {/* Icon — hidden for system toasts */}
+      {!isSystem && s.icon && (
+        <div className={`w-8 h-8 rounded-xl flex items-center justify-center text-sm font-bold flex-shrink-0 ${s.iconBg} ${s.iconColor}`}>
+          {s.icon}
+        </div>
+      )}
 
       {/* Text */}
       <div className="flex-1 min-w-0 pt-0.5">
@@ -51,7 +60,7 @@ function Toast({ toast, onDismiss }) {
 export default function ToastContainer({ toasts, onDismiss }) {
   if (toasts.length === 0) return null
   return (
-    <div className="fixed bottom-6 right-6 z-[100] flex flex-col gap-3 pointer-events-none">
+    <div className="fixed top-20 right-6 z-[100] flex flex-col gap-3 pointer-events-none">
       {toasts.map(toast => (
         <div key={toast.id} className="pointer-events-auto">
           <Toast toast={toast} onDismiss={onDismiss} />

--- a/frontend/src/context/BadgesContext.jsx
+++ b/frontend/src/context/BadgesContext.jsx
@@ -1,4 +1,5 @@
-import { createContext, useContext, useState, useEffect } from 'react'
+import { createContext, useContext, useState, useEffect, useRef } from 'react'
+import { useToast } from './ToastContext'
 
 export const BADGE_DEFINITIONS = [
   // ── Logins ──────────────────────────────────────────────────────────────────
@@ -44,24 +45,50 @@ export const BADGE_DEFINITIONS = [
 // TODO: replace with api.get('/profiles/badges') when backend endpoint is ready.
 // Expected response shape: [{ id: string, earnedAt: ISO string }]
 const MOCK_EARNED = [
-  { id: 'login_1',   earnedAt: '2026-03-15T10:00:00Z' },
-  { id: 'login_10',  earnedAt: '2026-04-01T09:00:00Z' },
-  { id: 'streak_3',  earnedAt: '2026-03-18T08:00:00Z' },
-  { id: 'streak_7',  earnedAt: '2026-04-29T08:00:00Z' },
-  { id: 'msg_1',     earnedAt: '2026-03-15T11:00:00Z' },
-  { id: 'msg_25',    earnedAt: '2026-04-10T14:00:00Z' },
-  { id: 'emoji_1',   earnedAt: '2026-04-30T15:00:00Z' },
-  { id: 'group_1',   earnedAt: '2026-03-15T12:00:00Z' },
-  { id: 'group_3',   earnedAt: '2026-04-20T10:00:00Z' },
-  { id: 'pts_100',   earnedAt: '2026-03-20T14:00:00Z' },
-  { id: 'pts_500',   earnedAt: '2026-04-15T16:00:00Z' },
-  { id: 'help_1',    earnedAt: '2026-04-25T13:00:00Z' },
-  { id: 'session_1', earnedAt: '2026-04-28T10:00:00Z' },
+  // logins — tiers 1 through 5
+  { id: 'login_1',    earnedAt: '2026-03-15T10:00:00Z' },
+  { id: 'login_10',   earnedAt: '2026-04-01T09:00:00Z' },
+  { id: 'login_25',   earnedAt: '2026-04-15T09:00:00Z' },
+  { id: 'login_50',   earnedAt: '2026-04-28T09:00:00Z' },
+  { id: 'login_100',  earnedAt: '2026-05-01T09:00:00Z' },
+  // streak — tiers 1 through 4
+  { id: 'streak_3',   earnedAt: '2026-03-18T08:00:00Z' },
+  { id: 'streak_7',   earnedAt: '2026-04-29T08:00:00Z' },
+  { id: 'streak_14',  earnedAt: '2026-04-22T08:00:00Z' },
+  { id: 'streak_30',  earnedAt: '2026-05-02T08:00:00Z' },
+  // messages — tiers 1 through 3
+  { id: 'msg_1',      earnedAt: '2026-03-15T11:00:00Z' },
+  { id: 'msg_25',     earnedAt: '2026-04-10T14:00:00Z' },
+  { id: 'msg_100',    earnedAt: '2026-04-28T14:00:00Z' },
+  // emojis — tiers 1 through 3
+  { id: 'emoji_1',    earnedAt: '2026-04-30T15:00:00Z' },
+  { id: 'emoji_10',   earnedAt: '2026-05-01T15:00:00Z' },
+  { id: 'emoji_50',   earnedAt: '2026-05-02T15:00:00Z' },
+  // groups — tiers 1 through 3
+  { id: 'group_1',    earnedAt: '2026-03-15T12:00:00Z' },
+  { id: 'group_3',    earnedAt: '2026-04-20T10:00:00Z' },
+  { id: 'group_5',    earnedAt: '2026-05-01T10:00:00Z' },
+  // sessions — tiers 1 through 4
+  { id: 'session_1',  earnedAt: '2026-04-28T10:00:00Z' },
+  { id: 'session_5',  earnedAt: '2026-04-30T10:00:00Z' },
+  { id: 'session_10', earnedAt: '2026-05-02T10:00:00Z' },
+  { id: 'session_25', earnedAt: '2026-05-03T10:00:00Z' },
+  // points — tiers 1 through 4
+  { id: 'pts_100',    earnedAt: '2026-03-20T14:00:00Z' },
+  { id: 'pts_500',    earnedAt: '2026-04-15T16:00:00Z' },
+  { id: 'pts_1000',   earnedAt: '2026-04-29T16:00:00Z' },
+  { id: 'pts_5000',   earnedAt: '2026-05-03T16:00:00Z' },
+  // helper — tiers 1 through 3
+  { id: 'help_1',     earnedAt: '2026-04-25T13:00:00Z' },
+  { id: 'help_5',     earnedAt: '2026-05-01T13:00:00Z' },
+  { id: 'help_10',    earnedAt: '2026-05-03T13:00:00Z' },
 ]
 
 const BadgesContext = createContext(null)
 
 export function BadgesProvider({ children }) {
+  const { addToast }          = useToast()
+  const hasToasted            = useRef(false)
   const [raw, setRaw]         = useState([])
   const [seenIds, setSeenIds] = useState(() => {
     try { return new Set(JSON.parse(localStorage.getItem('wsu-seen-badges') ?? '[]')) }
@@ -72,6 +99,51 @@ export function BadgesProvider({ children }) {
     // TODO: api.get('/profiles/badges').then(res => setRaw(res.data)).catch(() => setRaw(MOCK_EARNED))
     setRaw(MOCK_EARNED)
   }, [])
+
+  // Fire toasts once per session for newly earned badges
+  useEffect(() => {
+    if (raw.length === 0 || hasToasted.current) return
+    hasToasted.current = true
+
+    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+    const fresh = raw
+      .map(e => {
+        const def = BADGE_DEFINITIONS.find(b => b.id === e.id)
+        return def ? { ...def, earnedAt: e.earnedAt } : null
+      })
+      .filter(b => b && new Date(b.earnedAt) > sevenDaysAgo && !seenIds.has(b.id))
+      .sort((a, b) => b.tier - a.tier)
+
+    if (fresh.length === 0) return
+
+    const show = fresh.slice(0, 3)
+    show.forEach((badge, i) => {
+      setTimeout(() => {
+        addToast({
+          title: 'New Badge Earned!',
+          description: badge.name,
+          type: 'badge',
+          duration: 5000,
+        })
+      }, i * 600)
+    })
+
+    if (fresh.length > 3) {
+      setTimeout(() => {
+        addToast({
+          title: `+${fresh.length - 3} more badges earned`,
+          description: 'Check your profile to see them all.',
+          type: 'badge',
+          duration: 5000,
+        })
+      }, show.length * 600)
+    }
+
+    // Mark all as seen so toasts don't re-fire on next load
+    const next = new Set([...seenIds, ...fresh.map(b => b.id)])
+    setSeenIds(next)
+    localStorage.setItem('wsu-seen-badges', JSON.stringify([...next]))
+  }, [raw])
 
   const earned = raw
     .map(e => {

--- a/frontend/src/context/BadgesContext.jsx
+++ b/frontend/src/context/BadgesContext.jsx
@@ -1,0 +1,99 @@
+import { createContext, useContext, useState, useEffect } from 'react'
+
+export const BADGE_DEFINITIONS = [
+  // ── Logins ──────────────────────────────────────────────────────────────────
+  { id: 'login_1',    category: 'logins',   tier: 1, name: 'First Flight',      description: 'Logged in for the first time',          threshold: 1,    icon: '🦉' },
+  { id: 'login_10',   category: 'logins',   tier: 2, name: 'Regular Owl',       description: 'Logged in 10 times',                    threshold: 10,   icon: '🦉' },
+  { id: 'login_25',   category: 'logins',   tier: 3, name: 'Nest Dweller',      description: 'Logged in 25 times',                    threshold: 25,   icon: '🦉' },
+  { id: 'login_50',   category: 'logins',   tier: 4, name: 'Night Owl',         description: 'Logged in 50 times',                    threshold: 50,   icon: '🦉' },
+  { id: 'login_100',  category: 'logins',   tier: 5, name: 'Legendary Owl',     description: 'Logged in 100 times',                   threshold: 100,  icon: '🦉' },
+  // ── Streak ──────────────────────────────────────────────────────────────────
+  { id: 'streak_3',   category: 'streak',   tier: 1, name: 'On a Roll',         description: '3-day consecutive login streak',        threshold: 3,    icon: '🔥' },
+  { id: 'streak_7',   category: 'streak',   tier: 2, name: 'Week Warrior',      description: '7-day consecutive login streak',        threshold: 7,    icon: '🔥' },
+  { id: 'streak_14',  category: 'streak',   tier: 3, name: 'Fortnight Flame',   description: '14-day consecutive login streak',       threshold: 14,   icon: '🔥' },
+  { id: 'streak_30',  category: 'streak',   tier: 4, name: 'Monthly Blaze',     description: '30-day consecutive login streak',       threshold: 30,   icon: '🔥' },
+  // ── Messages ────────────────────────────────────────────────────────────────
+  { id: 'msg_1',      category: 'messages', tier: 1, name: 'First Word',        description: 'Sent your first message',               threshold: 1,    icon: '💬' },
+  { id: 'msg_25',     category: 'messages', tier: 2, name: 'Conversationalist', description: 'Sent 25 messages',                      threshold: 25,   icon: '💬' },
+  { id: 'msg_100',    category: 'messages', tier: 3, name: 'Chatterbox',        description: 'Sent 100 messages',                     threshold: 100,  icon: '💬' },
+  { id: 'msg_500',    category: 'messages', tier: 4, name: 'Voice of the Nest', description: 'Sent 500 messages',                     threshold: 500,  icon: '💬' },
+  // ── Emojis ──────────────────────────────────────────────────────────────────
+  { id: 'emoji_1',    category: 'emojis',   tier: 1, name: 'Expressive',        description: 'Sent your first emoji',                 threshold: 1,    icon: '😊' },
+  { id: 'emoji_10',   category: 'emojis',   tier: 2, name: 'Emoji Fan',         description: 'Sent 10 emojis',                        threshold: 10,   icon: '😊' },
+  { id: 'emoji_50',   category: 'emojis',   tier: 3, name: 'Emoji Master',      description: 'Sent 50 emojis',                        threshold: 50,   icon: '😊' },
+  // ── Groups ──────────────────────────────────────────────────────────────────
+  { id: 'group_1',    category: 'groups',   tier: 1, name: 'Team Player',       description: 'Joined your first study group',         threshold: 1,    icon: '👥' },
+  { id: 'group_3',    category: 'groups',   tier: 2, name: 'Collaborator',      description: 'Joined 3 study groups',                 threshold: 3,    icon: '👥' },
+  { id: 'group_5',    category: 'groups',   tier: 3, name: 'Network Builder',   description: 'Joined 5 study groups',                 threshold: 5,    icon: '👥' },
+  // ── Sessions ────────────────────────────────────────────────────────────────
+  { id: 'session_1',  category: 'sessions', tier: 1, name: 'First Session',     description: 'Attended your first study session',     threshold: 1,    icon: '📅' },
+  { id: 'session_5',  category: 'sessions', tier: 2, name: 'Regular Studier',   description: 'Attended 5 study sessions',             threshold: 5,    icon: '📅' },
+  { id: 'session_10', category: 'sessions', tier: 3, name: 'Dedicated Learner', description: 'Attended 10 study sessions',            threshold: 10,   icon: '📅' },
+  { id: 'session_25', category: 'sessions', tier: 4, name: 'Study Champion',    description: 'Attended 25 study sessions',            threshold: 25,   icon: '📅' },
+  // ── Points ──────────────────────────────────────────────────────────────────
+  { id: 'pts_100',    category: 'points',   tier: 1, name: 'Point Earner',      description: 'Earned 100 points',                     threshold: 100,  icon: '⭐' },
+  { id: 'pts_500',    category: 'points',   tier: 2, name: 'High Achiever',     description: 'Earned 500 points',                     threshold: 500,  icon: '⭐' },
+  { id: 'pts_1000',   category: 'points',   tier: 3, name: 'Wise Owl',          description: 'Earned 1,000 points',                   threshold: 1000, icon: '⭐' },
+  { id: 'pts_5000',   category: 'points',   tier: 4, name: 'Nest Guardian',     description: 'Earned 5,000 points',                   threshold: 5000, icon: '⭐' },
+  // ── Helper ──────────────────────────────────────────────────────────────────
+  { id: 'help_1',     category: 'helper',   tier: 1, name: 'Helpful Hand',      description: 'Helped a classmate for the first time', threshold: 1,    icon: '🤝' },
+  { id: 'help_5',     category: 'helper',   tier: 2, name: 'Mentor',            description: 'Helped 5 classmates',                   threshold: 5,    icon: '🤝' },
+  { id: 'help_10',    category: 'helper',   tier: 3, name: 'Campus Guide',      description: 'Helped 10 classmates',                  threshold: 10,   icon: '🤝' },
+]
+
+// TODO: replace with api.get('/profiles/badges') when backend endpoint is ready.
+// Expected response shape: [{ id: string, earnedAt: ISO string }]
+const MOCK_EARNED = [
+  { id: 'login_1',   earnedAt: '2026-03-15T10:00:00Z' },
+  { id: 'login_10',  earnedAt: '2026-04-01T09:00:00Z' },
+  { id: 'streak_3',  earnedAt: '2026-03-18T08:00:00Z' },
+  { id: 'streak_7',  earnedAt: '2026-04-29T08:00:00Z' },
+  { id: 'msg_1',     earnedAt: '2026-03-15T11:00:00Z' },
+  { id: 'msg_25',    earnedAt: '2026-04-10T14:00:00Z' },
+  { id: 'emoji_1',   earnedAt: '2026-04-30T15:00:00Z' },
+  { id: 'group_1',   earnedAt: '2026-03-15T12:00:00Z' },
+  { id: 'group_3',   earnedAt: '2026-04-20T10:00:00Z' },
+  { id: 'pts_100',   earnedAt: '2026-03-20T14:00:00Z' },
+  { id: 'pts_500',   earnedAt: '2026-04-15T16:00:00Z' },
+  { id: 'help_1',    earnedAt: '2026-04-25T13:00:00Z' },
+  { id: 'session_1', earnedAt: '2026-04-28T10:00:00Z' },
+]
+
+const BadgesContext = createContext(null)
+
+export function BadgesProvider({ children }) {
+  const [raw, setRaw]         = useState([])
+  const [seenIds, setSeenIds] = useState(() => {
+    try { return new Set(JSON.parse(localStorage.getItem('wsu-seen-badges') ?? '[]')) }
+    catch { return new Set() }
+  })
+
+  useEffect(() => {
+    // TODO: api.get('/profiles/badges').then(res => setRaw(res.data)).catch(() => setRaw(MOCK_EARNED))
+    setRaw(MOCK_EARNED)
+  }, [])
+
+  const earned = raw
+    .map(e => {
+      const def = BADGE_DEFINITIONS.find(b => b.id === e.id)
+      return def ? { ...def, earnedAt: e.earnedAt } : null
+    })
+    .filter(Boolean)
+
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+  const newBadges = earned.filter(b => new Date(b.earnedAt) > sevenDaysAgo && !seenIds.has(b.id))
+
+  const markAllSeen = () => {
+    const next = new Set([...seenIds, ...earned.map(b => b.id)])
+    setSeenIds(next)
+    localStorage.setItem('wsu-seen-badges', JSON.stringify([...next]))
+  }
+
+  return (
+    <BadgesContext.Provider value={{ earned, newBadges, markAllSeen }}>
+      {children}
+    </BadgesContext.Provider>
+  )
+}
+
+export const useBadges = () => useContext(BadgesContext)

--- a/frontend/src/context/ToastContext.jsx
+++ b/frontend/src/context/ToastContext.jsx
@@ -1,0 +1,30 @@
+import { createContext, useContext, useState, useCallback, useRef } from 'react'
+import ToastContainer from '../components/ToastContainer'
+
+const ToastContext = createContext(null)
+
+export function ToastProvider({ children }) {
+  const [toasts, setToasts] = useState([])
+  const counter = useRef(0)
+
+  const dismiss = useCallback((id) => {
+    setToasts(prev => prev.map(t => t.id === id ? { ...t, removing: true } : t))
+    setTimeout(() => setToasts(prev => prev.filter(t => t.id !== id)), 320)
+  }, [])
+
+  const addToast = useCallback(({ title, description, type = 'info', duration = 4500 }) => {
+    const id = ++counter.current
+    setToasts(prev => [...prev, { id, title, description, type, removing: false }])
+    if (duration > 0) setTimeout(() => dismiss(id), duration)
+    return id
+  }, [dismiss])
+
+  return (
+    <ToastContext.Provider value={{ addToast, dismiss }}>
+      {children}
+      <ToastContainer toasts={toasts} onDismiss={dismiss} />
+    </ToastContext.Provider>
+  )
+}
+
+export const useToast = () => useContext(ToastContext)

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -53,6 +53,8 @@ body {
   @apply text-wsu-slate text-lg max-w-2xl mx-auto;
 }
 
+/* Badge shapes are rendered as inline SVG in BadgeIcon.jsx */
+
 /* ── Form input styles ── */
 .form-input {
   @apply w-full border border-gray-200 rounded-lg px-4 py-3 text-wsu-navy 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -55,6 +55,15 @@ body {
 
 /* Badge shapes are rendered as inline SVG in BadgeIcon.jsx */
 
+/* Toast slide-in from right */
+@keyframes toast-slide-in {
+  from { transform: translateX(calc(100% + 1.5rem)); opacity: 0; }
+  to   { transform: translateX(0); opacity: 1; }
+}
+.animate-toast-in {
+  animation: toast-slide-in 0.3s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
 /* ── Form input styles ── */
 .form-input {
   @apply w-full border border-gray-200 rounded-lg px-4 py-3 text-wsu-navy 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom'
 import { AuthProvider } from './context/AuthContext'
 import { ThemeProvider } from './context/ThemeContext'
 import { EventsProvider } from './context/EventsContext'
+import { BadgesProvider } from './context/BadgesContext'
 import './index.css'
 import App from './App.jsx'
 
@@ -13,7 +14,9 @@ createRoot(document.getElementById('root')).render(
       <ThemeProvider>
         <AuthProvider>
           <EventsProvider>
-            <App />
+            <BadgesProvider>
+              <App />
+            </BadgesProvider>
           </EventsProvider>
         </AuthProvider>
       </ThemeProvider>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,6 +5,7 @@ import { AuthProvider } from './context/AuthContext'
 import { ThemeProvider } from './context/ThemeContext'
 import { EventsProvider } from './context/EventsContext'
 import { BadgesProvider } from './context/BadgesContext'
+import { ToastProvider } from './context/ToastContext'
 import './index.css'
 import App from './App.jsx'
 
@@ -13,11 +14,13 @@ createRoot(document.getElementById('root')).render(
     <BrowserRouter>
       <ThemeProvider>
         <AuthProvider>
-          <EventsProvider>
-            <BadgesProvider>
-              <App />
-            </BadgesProvider>
-          </EventsProvider>
+          <ToastProvider>
+            <EventsProvider>
+              <BadgesProvider>
+                <App />
+              </BadgesProvider>
+            </EventsProvider>
+          </ToastProvider>
         </AuthProvider>
       </ThemeProvider>
     </BrowserRouter>

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -1,16 +1,43 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import AppHeader from '../components/AppHeader'
+import BadgeIcon from '../components/BadgeIcon'
 import { useAuth } from '../context/AuthContext'
+import { useBadges } from '../context/BadgesContext'
 import api from '../api/axios'
 
 const YEAR_OPTIONS = ['Freshman', 'Sophomore', 'Junior', 'Senior']
 
+const CATEGORY_ORDER = ['logins', 'streak', 'messages', 'emojis', 'groups', 'sessions', 'points', 'helper']
+
+const CATEGORY_META = {
+  logins:   { label: 'Login Milestones',  hint: 'Log in to StudyNest to unlock these badges. Badges are awarded at 1, 10, 25, 50, and 100 logins.' },
+  streak:   { label: 'Login Streaks',     hint: 'Log in on consecutive days without missing one. Streaks of 3, 7, 14, and 30 days each earn a badge.' },
+  messages: { label: 'Messages Sent',     hint: 'Send messages in any group chat. Milestones at 1, 25, 100, and 500 messages.' },
+  emojis:   { label: 'Emojis Sent',       hint: 'Use the emoji button in group chat. Earned at 1, 10, and 50 emojis sent.' },
+  groups:   { label: 'Study Groups',      hint: 'Join study groups for your courses. Badges unlock at 1, 3, and 5 groups joined.' },
+  sessions: { label: 'Study Sessions',    hint: 'Attend scheduled study sessions. Milestones at 1, 5, 10, and 25 sessions.' },
+  points:   { label: 'Points Earned',     hint: 'Earn points through all your StudyNest activity. Awarded at 100, 500, 1,000, and 5,000 points.' },
+  helper:   { label: 'Helping Others',    hint: 'Help a classmate in a study group. Badges earned at 1, 5, and 10 assists.' },
+}
+
 function Profile() {
     const { profile, setProfile } = useAuth()
+    const { earned: badges }      = useBadges()
 
-    const [groups, setGroups]           = useState([])
-    const [dataLoading, setDataLoading] = useState(true)
+    const [groups, setGroups]               = useState([])
+    const [dataLoading, setDataLoading]     = useState(true)
+    const [showBadgesModal, setShowBadgesModal] = useState(false)
+
+    const topBadges = [...badges]
+        .sort((a, b) => b.tier - a.tier || new Date(b.earnedAt) - new Date(a.earnedAt))
+        .slice(0, 7)
+
+    const earnedByCategory = badges.reduce((acc, badge) => {
+        if (!acc[badge.category]) acc[badge.category] = []
+        acc[badge.category].push(badge)
+        return acc
+    }, {})
 
     const [editOpen, setEditOpen]       = useState(false)
     const [editForm, setEditForm]       = useState({ name: '', major: '', year: '', bio: '' })
@@ -108,19 +135,36 @@ function Profile() {
                         </div>
 
                         {/* Stats */}
-                        <div className="flex gap-6 mt-6 pt-6 border-t border-gray-100 dark:border-gray-700">
+                        <div className="flex items-start gap-6 mt-6 pt-6 border-t border-gray-100 dark:border-gray-700">
                             <div>
-                                <p className="text-xl font-display font-bold text-wsu-navy dark:text-white">
-                                    {dataLoading ? '—' : groups.length}
-                                </p>
-                                <p className="text-xs text-wsu-slate dark:text-gray-400 mt-0.5">Study Groups</p>
+                                <div className="h-8 flex items-end">
+                                    <p className="text-3xl leading-none font-display font-bold text-wsu-navy dark:text-white">
+                                        {dataLoading ? '—' : groups.length}
+                                    </p>
+                                </div>
+                                <p className="text-xs text-wsu-slate dark:text-gray-400 mt-1">Study Groups</p>
                             </div>
-                            <div className="w-px bg-gray-100 dark:bg-gray-700" />
+                            <div className="w-px self-stretch bg-gray-100 dark:bg-gray-700" />
                             <div>
-                                <p className="text-xl font-display font-bold text-wsu-navy dark:text-white">
-                                    {profile?.points ?? 0}
-                                </p>
-                                <p className="text-xs text-wsu-slate dark:text-gray-400 mt-0.5">Points 🏆</p>
+                                <div className="h-8 flex items-end">
+                                    <p className="text-3xl leading-none font-display font-bold text-wsu-navy dark:text-white">
+                                        {profile?.points ?? 0}
+                                    </p>
+                                </div>
+                                <p className="text-xs text-wsu-slate dark:text-gray-400 mt-1">Points</p>
+                            </div>
+                            <div className="w-px self-stretch bg-gray-100 dark:bg-gray-700" />
+                            <div>
+                                <div className="h-8 flex items-end">
+                                    <button
+                                        onClick={() => setShowBadgesModal(true)}
+                                        disabled={badges.length === 0}
+                                        className="text-3xl leading-none font-display font-bold text-wsu-navy dark:text-white hover:text-blue-700 dark:hover:text-blue-400 transition-colors disabled:hover:text-wsu-navy disabled:cursor-default"
+                                    >
+                                        {badges.length}
+                                    </button>
+                                </div>
+                                <p className="text-xs text-wsu-slate dark:text-gray-400 mt-1">Badges</p>
                             </div>
                         </div>
                     </div>
@@ -195,6 +239,62 @@ function Profile() {
                     )}
                 </div>
             </main>
+
+            {/* ── All Badges Modal ── */}
+            {showBadgesModal && (
+                <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center px-6 backdrop-blur-sm">
+                    <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-2xl max-w-lg w-full max-h-[80vh] flex flex-col animate-fade-up">
+
+                        {/* Header */}
+                        <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-gray-100 dark:border-gray-700 flex-shrink-0">
+                            <div>
+                                <h2 className="font-display text-xl text-wsu-navy dark:text-white">All Badges</h2>
+                                <p className="text-xs text-wsu-slate dark:text-gray-400 mt-0.5">{badges.length} earned</p>
+                            </div>
+                            <button
+                                onClick={() => setShowBadgesModal(false)}
+                                className="w-8 h-8 flex items-center justify-center rounded-xl hover:bg-wsu-mist dark:hover:bg-gray-800 text-wsu-slate text-xl leading-none transition-colors"
+                            >
+                                ×
+                            </button>
+                        </div>
+
+                        {/* Scrollable category tiles */}
+                        <div className="overflow-y-auto flex-1 px-5 py-5 grid grid-cols-2 gap-3 content-start">
+                            {CATEGORY_ORDER.map(cat => {
+                                const meta      = CATEGORY_META[cat]
+                                const catBadges = [...(earnedByCategory[cat] ?? [])].sort((a, b) => a.tier - b.tier)
+                                const hasEarned = catBadges.length > 0
+
+                                return hasEarned ? (
+                                    <div key={cat} className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-100 dark:border-gray-700 shadow-sm px-5 py-4">
+                                        <p className="text-xs font-semibold text-wsu-slate dark:text-gray-400 uppercase tracking-widest mb-3">
+                                            {meta.label}
+                                        </p>
+                                        <div className="flex -space-x-3">
+                                            {catBadges.map((badge, i) => (
+                                                <div key={badge.id} className="relative" style={{ zIndex: i }}>
+                                                    <BadgeIcon badge={badge} size="md" />
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                ) : (
+                                    <div key={cat} className="bg-wsu-mist dark:bg-gray-800/60 rounded-2xl border border-gray-100 dark:border-gray-700 px-5 py-4">
+                                        <p className="text-xs font-semibold text-wsu-slate/60 dark:text-gray-500 uppercase tracking-widest mb-2">
+                                            {meta.label}
+                                        </p>
+                                        <div className="flex items-start gap-2.5">
+                                            <span className="text-sm flex-shrink-0 mt-0.5">🔒</span>
+                                            <p className="text-xs text-wsu-slate dark:text-gray-400 leading-relaxed">{meta.hint}</p>
+                                        </div>
+                                    </div>
+                                )
+                            })}
+                        </div>
+                    </div>
+                </div>
+            )}
 
             {/* ── Edit Profile Modal ── */}
             {editOpen && (

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -155,16 +155,29 @@ function Profile() {
                             </div>
                             <div className="w-px self-stretch bg-gray-100 dark:bg-gray-700" />
                             <div>
-                                <div className="h-8 flex items-end">
-                                    <button
-                                        onClick={() => setShowBadgesModal(true)}
-                                        disabled={badges.length === 0}
-                                        className="text-3xl leading-none font-display font-bold text-wsu-navy dark:text-white hover:text-blue-700 dark:hover:text-blue-400 transition-colors disabled:hover:text-wsu-navy disabled:cursor-default"
-                                    >
-                                        {badges.length}
-                                    </button>
+                                <div className="h-8 flex items-center">
+                                    {badges.length === 0 ? (
+                                        <p className="text-3xl leading-none font-display font-bold text-wsu-slate dark:text-gray-500">—</p>
+                                    ) : (
+                                        <div
+                                            className="flex items-center -space-x-3 cursor-pointer"
+                                            onClick={() => setShowBadgesModal(true)}
+                                        >
+                                            {[...topBadges].reverse().map((badge, i) => (
+                                                <div key={badge.id} className="relative" style={{ zIndex: i }}>
+                                                    <BadgeIcon badge={badge} size="sm" />
+                                                </div>
+                                            ))}
+                                        </div>
+                                    )}
                                 </div>
-                                <p className="text-xs text-wsu-slate dark:text-gray-400 mt-1">Badges</p>
+                                <button
+                                    onClick={() => setShowBadgesModal(true)}
+                                    disabled={badges.length === 0}
+                                    className="text-xs text-wsu-slate dark:text-gray-400 mt-1 hover:text-blue-700 dark:hover:text-blue-400 hover:underline transition-colors disabled:cursor-default disabled:no-underline"
+                                >
+                                    Badges
+                                </button>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Implements a frontend badge system tied to the app's gamification features. 
- Users earn badges (in various ways) based on their activity. 
- Badge count is displayed on the profile stats bar - clickable to expand to view all badges organized by category.

## Changes
- Added badge 8 categories (logins, streaks, messages, emojis, groups, sessions, points, helper) - Can certainly expand on this if desired.
- Current user badges are filled with mock data - TODO comments mark where the real API call goes once the backend endpoint is ready
- Added  SVG badge component with category-specific shapes, tier-based colors, Roman numeral tier indicators (I–V), and 3D gradient/shadow effects for a bit of depth
- Updated "Profile.jsx" stats bar to show earned badge count as a clickable number that opens an expandable modal
- Badge modal organizes badges into category tiles — earned categories show overlapping badge icons, locked categories show a description of how to earn them
- Wrapped app with "BadgesProvider" in "main.jsx"

## Testing
- Manually tested (locally)

## Notes for Reviewer
As mentioned, Badge data is currently mock data. When the backend badge endpoint is ready, swap the mock data in "BadgesContext.jsx" where the TODO comment is marked. Shouldn't be too difficult to tie together