### PR TITLE
Feature/meeting scheduler

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,6 +16,7 @@ import VerifyPending from './pages/VerifyPending'
 import VerifySuccess from './pages/VerifySuccess'
 import VerifyError from './pages/VerifyError'
 import Leaderboard from './pages/Leaderboard'
+import Meetings from './pages/Meetings'
 
 // Requires a token, but blocks users who already have a profile
 // (prevents someone from re-running setup and overwriting their data)
@@ -56,6 +57,7 @@ function App() {
       <Route path="/group-chat/:groupId" element={<ProtectedRoute><GroupChat /></ProtectedRoute>}    />
       <Route path="/change-password"     element={<ProtectedRoute><ChangePassword /></ProtectedRoute>} />
       <Route path="/leaderboard"          element={<ProtectedRoute><Leaderboard /></ProtectedRoute>} />
+      <Route path="/meetings"             element={<ProtectedRoute><Meetings /></ProtectedRoute>}    />
     </Routes>
   )
 }

--- a/frontend/src/components/AppHeader.jsx
+++ b/frontend/src/components/AppHeader.jsx
@@ -72,6 +72,7 @@ function AppHeader() {
     const navLinks = [
         { label: 'Study Groups', to: '/study-groups' },
         { label: 'Group Chats',  to: '/group-chat'   },
+        { label: 'Meetings',     to: '/meetings'     },
         { label: 'Leaderboard',  to: '/leaderboard'  },
     ]
 

--- a/frontend/src/components/MeetingScheduleModal.jsx
+++ b/frontend/src/components/MeetingScheduleModal.jsx
@@ -1,0 +1,284 @@
+import { useState } from 'react'
+import { useMeetings } from '../context/MeetingsContext'
+
+const DURATION_OPTIONS = [15, 30, 45, 60, 75, 90, 120, 150, 180]
+
+function defaultDatetime() {
+  const d = new Date()
+  d.setDate(d.getDate() + 1)
+  d.setHours(12, 0, 0, 0)
+  return d.toISOString().slice(0, 16)
+}
+
+// Converts an ISO/LocalDateTime string into the value format that <input type="datetime-local">
+// expects (YYYY-MM-DDTHH:mm in local time).
+function toLocalInputValue(isoStr) {
+  const d = new Date(isoStr)
+  if (isNaN(d.getTime())) return defaultDatetime()
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+// Schedules or edits a real meeting against the /meetings backend.
+//
+// Modes (controlled by props):
+//   • create     — no editingSession. Creates a new session with all fields.
+//   • reschedule — editingSession provided, mode='reschedule' (default). ONLY changes the date/time.
+//   • details    — editingSession provided, mode='details'. ONLY changes duration / location / notes.
+function MeetingScheduleModal({ groups, defaultGroupId, editingSession, mode = 'reschedule', onClose, onScheduled }) {
+  const { scheduleSession, rescheduleSession } = useMeetings()
+  const isEditing       = Boolean(editingSession)
+  const isDetailsOnly   = isEditing && mode === 'details'
+  const isRescheduling  = isEditing && mode === 'reschedule'
+
+  const [groupId,  setGroupId]  = useState(
+    editingSession?.studyGroup?.id ?? defaultGroupId ?? groups?.[0]?.id ?? ''
+  )
+  const [datetime, setDatetime] = useState(
+    editingSession ? toLocalInputValue(editingSession.scheduledAt) : defaultDatetime()
+  )
+  const [duration, setDuration] = useState(editingSession?.durationMinutes ?? 60)
+  const [location, setLocation] = useState(editingSession?.location ?? '')
+  const [notes,    setNotes]    = useState(editingSession?.notes ?? '')
+  const [loading,  setLoading]  = useState(false)
+  const [error,    setError]    = useState(null)
+  const [done,     setDone]     = useState(false)
+
+  const setClientError = (message) =>
+    setError({ message, code: 'CLIENT_VALIDATION', reference: null })
+
+  const setServerError = (err) => {
+    const data = err?.response?.data ?? {}
+    const status = err?.response?.status
+    const isNetwork = !err?.response
+    const fallback = isEditing
+      ? (isDetailsOnly ? 'Failed to update details.' : 'Failed to reschedule.')
+      : 'Failed to schedule session.'
+    const ref = `LOCAL-${Date.now().toString(36).toUpperCase()}`
+    console.error(`[${data.reference ?? ref}]`, err)
+    setError({
+      message:   data.message ?? (isNetwork ? 'Network error — check your connection and try again.' : fallback),
+      code:      data.code ?? (isNetwork ? 'NETWORK' : status ? `HTTP_${status}` : 'UNKNOWN'),
+      reference: data.reference ?? ref,
+    })
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError(null)
+
+    if (!isEditing && !groupId) {
+      setClientError('Please choose a group before scheduling.')
+      return
+    }
+
+    // Time validation only matters when actually setting a time
+    let localScheduledAt = null
+    if (!isDetailsOnly) {
+      const when = new Date(datetime)
+      if (isNaN(when.getTime())) {
+        setClientError('Please pick a valid date and time.')
+        return
+      }
+      if (when.getTime() <= Date.now()) {
+        setClientError('Session must be scheduled for a future time — meetings cannot start in the past.')
+        return
+      }
+      // Send the input value as-is (local time, no timezone). Going through Date.toISOString()
+      // converts to UTC and shifts the wall-clock hours, which the backend then stores as
+      // LocalDateTime — losing the offset and showing up wrong on read-back.
+      localScheduledAt = datetime.length === 16 ? `${datetime}:00` : datetime
+    }
+
+    setLoading(true)
+    try {
+      // Mode-specific payloads. Backend treats null/missing fields on PATCH as "leave alone",
+      // so sending only the fields that belong to the current mode ensures other fields stay put.
+      if (isRescheduling) {
+        await rescheduleSession(editingSession.id, { scheduledAt: localScheduledAt })
+      } else if (isDetailsOnly) {
+        await rescheduleSession(editingSession.id, {
+          scheduledAt: null,
+          durationMinutes: duration ? Number(duration) : null,
+          location,
+          notes,
+        })
+      } else {
+        await scheduleSession(Number(groupId), {
+          scheduledAt: localScheduledAt,
+          durationMinutes: duration ? Number(duration) : null,
+          location,
+          notes,
+        })
+      }
+      setDone(true)
+      if (onScheduled) onScheduled()
+      setTimeout(onClose, 1500)
+    } catch (err) {
+      setServerError(err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const heading =
+    !isEditing      ? 'Schedule Meeting'
+    : isDetailsOnly ? 'Edit Details'
+    :                 'Reschedule Meeting'
+
+  const subheading =
+    !isEditing      ? 'Notifies all group members'
+    : isDetailsOnly ? `${editingSession.studyGroup?.name ?? 'Study group'} — time will not change`
+    :                 `${editingSession.studyGroup?.name ?? 'Study group'} — members will be notified`
+
+  const successText =
+    !isEditing      ? 'Meeting scheduled!'
+    : isDetailsOnly ? 'Details updated!'
+    :                 'Meeting rescheduled!'
+
+  const submitText =
+    !isEditing      ? 'Schedule Meeting'
+    : isDetailsOnly ? 'Save Details'
+    :                 'Save Changes'
+
+  return (
+    <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center px-6 backdrop-blur-sm">
+      <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-2xl w-full max-w-md animate-fade-up">
+        <div className="px-8 pt-8 pb-6">
+          <div className="flex items-start justify-between mb-6">
+            <div>
+              <h2 className="font-display text-2xl text-wsu-navy dark:text-white">{heading}</h2>
+              <p className="text-xs text-wsu-slate dark:text-gray-400 mt-0.5">{subheading}</p>
+            </div>
+            <button
+              onClick={onClose}
+              className="w-8 h-8 flex items-center justify-center rounded-xl hover:bg-wsu-mist dark:hover:bg-gray-800 text-wsu-slate dark:text-gray-400 text-xl leading-none transition-colors"
+            >
+              ×
+            </button>
+          </div>
+
+          {done ? (
+            <div className="text-center py-8">
+              <div className="text-5xl mb-4">📅</div>
+              <p className="font-semibold text-wsu-navy dark:text-white text-lg">{successText}</p>
+              <p className="text-sm text-wsu-slate dark:text-gray-400 mt-1">
+                {isDetailsOnly ? 'Your changes have been saved.' : 'All group members have been notified.'}
+              </p>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              {error && (
+                <div className="bg-red-50 dark:bg-red-900/20 rounded-lg px-3 py-2">
+                  <p className="text-sm text-red-700 dark:text-red-400">{error.message}</p>
+                  <p className="mt-1 font-mono text-[10px] text-red-500/80 dark:text-red-400/70 select-all">
+                    code: {error.code}{error.reference ? ` · ref: ${error.reference}` : ''}
+                  </p>
+                </div>
+              )}
+
+              {!isEditing && (
+                <div>
+                  <label className="form-label dark:text-gray-200">Study Group</label>
+                  <select
+                    required
+                    className="form-input dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                    value={groupId}
+                    onChange={e => setGroupId(e.target.value)}
+                  >
+                    <option value="" disabled>Select a group...</option>
+                    {(groups ?? []).map(g => (
+                      <option key={g.id} value={g.id}>
+                        {g.name}{g.course?.courseCode ? ` · ${g.course.courseCode}` : ''}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
+
+              {!isDetailsOnly && (
+                <div>
+                  <label className="form-label dark:text-gray-200">Date & Time</label>
+                  <input
+                    type="datetime-local"
+                    required
+                    className="form-input dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                    value={datetime}
+                    onChange={e => setDatetime(e.target.value)}
+                  />
+                </div>
+              )}
+
+              {!isRescheduling && (
+                <>
+                  <div>
+                    <label className="form-label dark:text-gray-200">
+                      Duration <span className="font-normal text-wsu-slate dark:text-gray-500">(minutes)</span>
+                    </label>
+                    <select
+                      className="form-input dark:bg-gray-800 dark:border-gray-700 dark:text-white"
+                      value={duration ?? ''}
+                      onChange={e => setDuration(e.target.value ? Number(e.target.value) : null)}
+                    >
+                      <option value="">Unspecified</option>
+                      {DURATION_OPTIONS.map(m => (
+                        <option key={m} value={m}>
+                          {m < 60 ? `${m} min` : m % 60 === 0 ? `${m / 60} hr` : `${Math.floor(m / 60)} hr ${m % 60} min`}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div>
+                    <label className="form-label dark:text-gray-200">
+                      Location <span className="font-normal text-wsu-slate dark:text-gray-500">(optional)</span>
+                    </label>
+                    <input
+                      type="text"
+                      placeholder="e.g. Ely Library Rm 204 or Zoom"
+                      className="form-input dark:bg-gray-800 dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                      value={location}
+                      onChange={e => setLocation(e.target.value)}
+                    />
+                  </div>
+
+                  <div>
+                    <label className="form-label dark:text-gray-200">
+                      Notes <span className="font-normal text-wsu-slate dark:text-gray-500">(optional)</span>
+                    </label>
+                    <textarea
+                      rows={3}
+                      placeholder="Agenda, chapters to review, things to bring..."
+                      className="form-input resize-none dark:bg-gray-800 dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                      value={notes}
+                      onChange={e => setNotes(e.target.value)}
+                    />
+                  </div>
+                </>
+              )}
+
+              <div className="flex gap-3 pt-1">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="flex-1 py-3 rounded-xl border border-gray-200 dark:border-gray-700 text-wsu-navy dark:text-gray-200 text-sm font-semibold hover:bg-wsu-mist dark:hover:bg-gray-800 transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={loading}
+                  className="flex-1 py-3 bg-blue-700 hover:bg-blue-800 text-white text-sm font-semibold rounded-xl transition-all disabled:opacity-60"
+                >
+                  {loading ? 'Saving...' : submitText}
+                </button>
+              </div>
+            </form>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default MeetingScheduleModal

--- a/frontend/src/context/MeetingsContext.jsx
+++ b/frontend/src/context/MeetingsContext.jsx
@@ -1,0 +1,133 @@
+import { createContext, useContext, useState, useCallback } from 'react'
+import api from '../api/axios'
+
+const MeetingsContext = createContext(null)
+
+/**
+ * Wraps the /meetings REST API and caches the results in React state so multiple
+ * components can share a consistent view without each one re-fetching. Cancellations,
+ * reschedules, and edits update both the per-group cache and the cross-group "upcoming"
+ * list optimistically — no extra refetch is needed after a mutation succeeds.
+ *
+ * Exposed via `useMeetings()`:
+ *   • upcoming, loadingUpcoming   — the cross-group future-sessions list and its loading flag
+ *   • fetchUpcoming()             — refresh the upcoming list (call once on page mount)
+ *   • fetchGroupSessions(groupId) — refresh sessions for one group; returns the array
+ *   • getGroupSessions(groupId)   — read the cached array (no fetch)
+ *   • scheduleSession(groupId, fields)            — POST  /meetings
+ *   • rescheduleSession(sessionId, fields)        — PATCH /meetings/{id}; pass scheduledAt:null
+ *                                                   to leave the time alone (details-only edit)
+ *   • cancelSession(sessionId, groupId)           — DELETE /meetings/{id}
+ */
+export function MeetingsProvider({ children }) {
+  const [sessionsByGroup, setSessionsByGroup] = useState({})
+  const [upcoming, setUpcoming]               = useState([])
+  const [loadingUpcoming, setLoadingUpcoming] = useState(false)
+
+  // Loads the per-group cache. Swallows errors so the UI just shows an empty list
+  // instead of crashing — the page is read-only and a 403/404 just means "nothing to show."
+  const fetchGroupSessions = useCallback(async (groupId) => {
+    if (!groupId) return []
+    try {
+      const res = await api.get(`/meetings/group/${groupId}`)
+      setSessionsByGroup(prev => ({ ...prev, [groupId]: res.data }))
+      return res.data
+    } catch {
+      return []
+    }
+  }, [])
+
+  const fetchUpcoming = useCallback(async () => {
+    setLoadingUpcoming(true)
+    try {
+      const res = await api.get('/meetings/upcoming')
+      setUpcoming(res.data)
+      return res.data
+    } catch {
+      setUpcoming([])
+      return []
+    } finally {
+      setLoadingUpcoming(false)
+    }
+  }, [])
+
+  const scheduleSession = async (groupId, { scheduledAt, location, notes, durationMinutes }) => {
+    const res = await api.post('/meetings', {
+      groupId,
+      scheduledAt,
+      durationMinutes: durationMinutes ?? null,
+      location: location || null,
+      notes:    notes    || null,
+    })
+    const session = res.data
+    setSessionsByGroup(prev => {
+      const list = [...(prev[groupId] ?? []), session]
+        .sort((a, b) => new Date(a.scheduledAt) - new Date(b.scheduledAt))
+      return { ...prev, [groupId]: list }
+    })
+    setUpcoming(prev => [...prev, session]
+      .sort((a, b) => new Date(a.scheduledAt) - new Date(b.scheduledAt)))
+    return session
+  }
+
+  const rescheduleSession = async (sessionId, { scheduledAt, location, notes, durationMinutes }) => {
+    // scheduledAt may be null = details-only edit; backend leaves the existing time alone.
+    const res = await api.patch(`/meetings/${sessionId}`, {
+      scheduledAt: scheduledAt ?? null,
+      durationMinutes: durationMinutes ?? null,
+      location: location ?? null,
+      notes:    notes    ?? null,
+    })
+    const updated = res.data
+    const updateInList = (list) => (list ?? [])
+      .map(s => s.id === sessionId ? updated : s)
+      .sort((a, b) => new Date(a.scheduledAt) - new Date(b.scheduledAt))
+    setUpcoming(prev => updateInList(prev))
+    setSessionsByGroup(prev => {
+      const next = {}
+      for (const [gid, list] of Object.entries(prev)) next[gid] = updateInList(list)
+      return next
+    })
+    return updated
+  }
+
+  const cancelSession = async (sessionId, groupId) => {
+    await api.delete(`/meetings/${sessionId}`)
+    setUpcoming(prev => prev.filter(s => s.id !== sessionId))
+    if (groupId != null) {
+      setSessionsByGroup(prev => ({
+        ...prev,
+        [groupId]: (prev[groupId] ?? []).filter(s => s.id !== sessionId),
+      }))
+    } else {
+      // groupId may be missing if the caller didn't have it handy — fall back to
+      // sweeping every cached group, since the cancelled session is in at most one.
+      setSessionsByGroup(prev => {
+        const next = {}
+        for (const [gid, list] of Object.entries(prev)) {
+          next[gid] = list.filter(s => s.id !== sessionId)
+        }
+        return next
+      })
+    }
+  }
+
+  const getGroupSessions = (groupId) => sessionsByGroup[groupId] ?? []
+
+  return (
+    <MeetingsContext.Provider value={{
+      upcoming,
+      loadingUpcoming,
+      fetchUpcoming,
+      fetchGroupSessions,
+      getGroupSessions,
+      scheduleSession,
+      rescheduleSession,
+      cancelSession,
+    }}>
+      {children}
+    </MeetingsContext.Provider>
+  )
+}
+
+export const useMeetings = () => useContext(MeetingsContext)

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom'
 import { AuthProvider } from './context/AuthContext'
 import { ThemeProvider } from './context/ThemeContext'
 import { EventsProvider } from './context/EventsContext'
+import { MeetingsProvider } from './context/MeetingsContext'
 import { BadgesProvider } from './context/BadgesContext'
 import { ToastProvider } from './context/ToastContext'
 import './index.css'
@@ -16,9 +17,11 @@ createRoot(document.getElementById('root')).render(
         <AuthProvider>
           <ToastProvider>
             <EventsProvider>
-              <BadgesProvider>
-                <App />
-              </BadgesProvider>
+              <MeetingsProvider>
+                <BadgesProvider>
+                  <App />
+                </BadgesProvider>
+              </MeetingsProvider>
             </EventsProvider>
           </ToastProvider>
         </AuthProvider>

--- a/frontend/src/pages/Meetings.jsx
+++ b/frontend/src/pages/Meetings.jsx
@@ -1,0 +1,283 @@
+/**
+ * /meetings page — shows the logged-in student's upcoming sessions across every group
+ * they belong to, grouped into Today / Tomorrow / This Week / Later. The session creator
+ * sees three actions per row: Edit details, Reschedule, and Cancel; everyone else only
+ * sees the "Open chat" link. Schedule and edit flows both reuse MeetingScheduleModal —
+ * the mode prop drives which fields are shown.
+ */
+import { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import AppHeader from '../components/AppHeader'
+import MeetingScheduleModal from '../components/MeetingScheduleModal'
+import { useAuth } from '../context/AuthContext'
+import { useMeetings } from '../context/MeetingsContext'
+import api from '../api/axios'
+import campusPhoto from '../assets/CampusStock_Apr2023_025-X4.jpg'
+
+// "Tue, May 5, 2026 · 03:00 PM – 04:00 PM" when duration is set,
+// "Tue, May 5, 2026 · 03:00 PM" when it isn't.
+function formatLong(isoStr, durationMinutes) {
+  const d = new Date(isoStr)
+  const date = d.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' })
+  const time = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  if (durationMinutes && Number.isFinite(durationMinutes)) {
+    const end = new Date(d.getTime() + durationMinutes * 60_000)
+    const endTime = end.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    return `${date} · ${time} – ${endTime}`
+  }
+  return `${date} · ${time}`
+}
+
+// "45 min", "1 hr", "1 hr 30 min". Returns null for missing/invalid input so the caller
+// can render nothing instead of "0 min" or "NaN min".
+function formatDuration(minutes) {
+  if (!minutes || !Number.isFinite(minutes)) return null
+  if (minutes < 60) return `${minutes} min`
+  const hrs = Math.floor(minutes / 60)
+  const rem = minutes % 60
+  return rem === 0 ? `${hrs} hr` : `${hrs} hr ${rem} min`
+}
+
+// Maps a session's scheduledAt to one of four labels driving the section headers.
+// Uses local-midnight boundaries so a 1 AM meeting still counts as "Today" and an
+// 11 PM meeting today doesn't slip into "Tomorrow".
+function relativeBucket(isoStr) {
+  const d = new Date(isoStr)
+  const now = new Date()
+  const today = new Date(now); today.setHours(0, 0, 0, 0)
+  const tom   = new Date(today); tom.setDate(tom.getDate() + 1)
+  const week  = new Date(today); week.setDate(week.getDate() + 7)
+
+  if (d < tom)  return 'Today'
+  if (d < new Date(tom.getTime() + 86400000)) return 'Tomorrow'
+  if (d < week) return 'This Week'
+  return 'Later'
+}
+
+function Meetings() {
+  const { profile } = useAuth()
+  const { upcoming, loadingUpcoming, fetchUpcoming, cancelSession } = useMeetings()
+
+  const [groups, setGroups]         = useState([])
+  const [groupsLoading, setGroupsLoading] = useState(true)
+  const [showModal, setShowModal]   = useState(false)
+  // editing = { session, mode } where mode is 'reschedule' or 'details', or null when not editing
+  const [editing,   setEditing]     = useState(null)
+  const [cancelError, setCancelError] = useState(null)
+
+  useEffect(() => {
+    fetchUpcoming()
+  }, [fetchUpcoming])
+
+  useEffect(() => {
+    setGroupsLoading(true)
+    api.get('/groups/my')
+      .then(res => setGroups(Array.isArray(res.data) ? res.data : []))
+      .catch(() => setGroups([]))
+      .finally(() => setGroupsLoading(false))
+  }, [])
+
+  const buckets = useMemo(() => {
+    const order = ['Today', 'Tomorrow', 'This Week', 'Later']
+    const map = Object.fromEntries(order.map(k => [k, []]))
+    for (const s of upcoming) map[relativeBucket(s.scheduledAt)].push(s)
+    return order.map(label => ({ label, sessions: map[label] }))
+                .filter(b => b.sessions.length > 0)
+  }, [upcoming])
+
+  const handleCancel = async (session) => {
+    setCancelError(null)
+    if (!window.confirm('Cancel this meeting? All members will lose this on their list.')) return
+    try {
+      await cancelSession(session.id, session.studyGroup?.id)
+    } catch (err) {
+      const data = err?.response?.data ?? {}
+      const status = err?.response?.status
+      const isNetwork = !err?.response
+      const ref = `LOCAL-${Date.now().toString(36).toUpperCase()}`
+      console.error(`[${data.reference ?? ref}]`, err)
+      setCancelError({
+        message:   data.message ?? (isNetwork ? 'Network error — check your connection and try again.' : 'Failed to cancel meeting.'),
+        code:      data.code ?? (isNetwork ? 'NETWORK' : status ? `HTTP_${status}` : 'UNKNOWN'),
+        reference: data.reference ?? ref,
+      })
+    }
+  }
+
+  const isOwner = (session) => session.scheduledBy?.id === profile?.id
+
+  return (
+    <div
+      className="flex flex-col min-h-screen bg-cover bg-center bg-fixed transition-colors duration-300"
+      style={{ backgroundImage: `url(${campusPhoto})` }}
+    >
+      <AppHeader />
+
+      <main className="flex-1 pt-24 pb-12 max-w-5xl mx-auto w-full px-4 md:px-6">
+
+        <div className="bg-white/95 dark:bg-gray-900/95 backdrop-blur rounded-2xl shadow-sm border border-gray-100 dark:border-gray-800 p-6 md:p-8 mb-6">
+          <div className="flex items-start justify-between gap-4 flex-wrap">
+            <div>
+              <h1 className="font-display text-3xl text-wsu-navy dark:text-white">Meetings</h1>
+              <p className="text-sm text-wsu-slate dark:text-gray-400 mt-1">
+                Upcoming study sessions across all your groups.
+              </p>
+            </div>
+            <button
+              onClick={() => setShowModal(true)}
+              disabled={groupsLoading || groups.length === 0}
+              className="flex items-center gap-2 px-4 py-2.5 bg-blue-700 hover:bg-blue-800 text-white text-sm font-semibold rounded-xl shadow-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <span>📅</span>
+              Schedule Meeting
+            </button>
+          </div>
+        </div>
+
+        {cancelError && (
+          <div className="mb-4 p-3 rounded-xl bg-red-50 dark:bg-red-900/20">
+            <p className="text-sm text-red-700 dark:text-red-400">{cancelError.message}</p>
+            <p className="mt-1 font-mono text-[10px] text-red-500/80 dark:text-red-400/70 select-all">
+              code: {cancelError.code}{cancelError.reference ? ` · ref: ${cancelError.reference}` : ''}
+            </p>
+          </div>
+        )}
+
+        <div className="bg-white/95 dark:bg-gray-900/95 backdrop-blur rounded-2xl shadow-sm border border-gray-100 dark:border-gray-800 p-6 md:p-8">
+          {loadingUpcoming ? (
+            <div className="flex justify-center py-16">
+              <div className="animate-spin w-8 h-8 border-4 border-blue-700 border-t-transparent rounded-full" />
+            </div>
+          ) : upcoming.length === 0 ? (
+            <div className="text-center py-16">
+              <div className="text-5xl mb-3">📅</div>
+              <p className="font-semibold text-wsu-navy dark:text-white text-lg">No upcoming meetings</p>
+              <p className="text-sm text-wsu-slate dark:text-gray-400 mt-1">
+                {groups.length === 0
+                  ? 'Join a study group to start scheduling.'
+                  : 'Schedule a meeting to see it here.'}
+              </p>
+              {groups.length === 0 && (
+                <Link
+                  to="/study-groups"
+                  className="inline-block mt-4 text-sm text-blue-700 dark:text-blue-400 font-semibold hover:underline"
+                >
+                  Browse study groups →
+                </Link>
+              )}
+            </div>
+          ) : (
+            <div className="space-y-8">
+              {buckets.map(bucket => (
+                <section key={bucket.label}>
+                  <h2 className="text-xs font-bold uppercase tracking-wider text-wsu-slate dark:text-gray-400 mb-3">
+                    {bucket.label}
+                  </h2>
+                  <ul className="space-y-3">
+                    {bucket.sessions.map(s => (
+                      <li
+                        key={s.id}
+                        className="flex items-start gap-4 p-4 rounded-xl border border-gray-100 dark:border-gray-800 bg-wsu-mist/40 dark:bg-gray-800/40 hover:bg-wsu-mist dark:hover:bg-gray-800 transition-colors"
+                      >
+                        <div className="w-10 h-10 bg-blue-100 dark:bg-blue-900/40 rounded-xl flex items-center justify-center flex-shrink-0 mt-0.5">
+                          <span className="text-lg">📅</span>
+                        </div>
+
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <p className="text-sm font-semibold text-wsu-navy dark:text-white">
+                              {s.studyGroup?.name ?? 'Study Session'}
+                            </p>
+                            {s.studyGroup?.course?.courseCode && (
+                              <span className="text-xs px-2 py-0.5 rounded-full bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 font-medium">
+                                {s.studyGroup.course.courseCode}
+                              </span>
+                            )}
+                          </div>
+                          <p className="text-xs text-blue-600 dark:text-blue-400 font-medium mt-0.5">
+                            {formatLong(s.scheduledAt, s.durationMinutes)}
+                            {s.durationMinutes && (
+                              <span className="text-wsu-slate dark:text-gray-400 font-normal ml-2">
+                                · {formatDuration(s.durationMinutes)}
+                              </span>
+                            )}
+                          </p>
+                          {s.location && (
+                            <p className="text-xs text-wsu-slate dark:text-gray-400 mt-1">
+                              📍 {s.location}
+                            </p>
+                          )}
+                          {s.notes && (
+                            <p className="text-xs text-wsu-slate dark:text-gray-400 mt-1 line-clamp-2">
+                              {s.notes}
+                            </p>
+                          )}
+                          <p className="text-xs text-wsu-slate dark:text-gray-500 mt-1">
+                            Scheduled by {s.scheduledBy?.name ?? 'someone'}
+                          </p>
+                        </div>
+
+                        <div className="flex flex-col items-end gap-2 flex-shrink-0">
+                          {s.studyGroup?.id && (
+                            <Link
+                              to={`/group-chat/${s.studyGroup.id}`}
+                              className="text-xs px-3 py-1.5 rounded-lg border border-gray-200 dark:border-gray-700 text-wsu-navy dark:text-gray-200 font-semibold hover:bg-white dark:hover:bg-gray-700 transition-colors"
+                            >
+                              Open chat
+                            </Link>
+                          )}
+                          {isOwner(s) && (
+                            <>
+                              <button
+                                onClick={() => setEditing({ session: s, mode: 'details' })}
+                                className="text-xs px-3 py-1.5 rounded-lg text-wsu-navy dark:text-gray-200 hover:bg-wsu-mist dark:hover:bg-gray-700 font-semibold transition-colors"
+                              >
+                                Edit details
+                              </button>
+                              <button
+                                onClick={() => setEditing({ session: s, mode: 'reschedule' })}
+                                className="text-xs px-3 py-1.5 rounded-lg text-blue-700 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 font-semibold transition-colors"
+                              >
+                                Reschedule
+                              </button>
+                              <button
+                                onClick={() => handleCancel(s)}
+                                className="text-xs px-3 py-1.5 rounded-lg text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 font-semibold transition-colors"
+                              >
+                                Cancel
+                              </button>
+                            </>
+                          )}
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+
+      {showModal && (
+        <MeetingScheduleModal
+          groups={groups}
+          onClose={() => setShowModal(false)}
+          onScheduled={fetchUpcoming}
+        />
+      )}
+
+      {editing && (
+        <MeetingScheduleModal
+          groups={groups}
+          editingSession={editing.session}
+          mode={editing.mode}
+          onClose={() => setEditing(null)}
+          onScheduled={fetchUpcoming}
+        />
+      )}
+    </div>
+  )
+}
+
+export default Meetings

--- a/src/main/java/com/github/wsustudygroupapp/config/SecurityConfig.java
+++ b/src/main/java/com/github/wsustudygroupapp/config/SecurityConfig.java
@@ -71,7 +71,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOrigins(List.of(frontendUrl));
-        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);
 

--- a/src/main/java/com/github/wsustudygroupapp/controller/MeetingSessionController.java
+++ b/src/main/java/com/github/wsustudygroupapp/controller/MeetingSessionController.java
@@ -1,8 +1,10 @@
 package com.github.wsustudygroupapp.controller;
 
+import com.github.wsustudygroupapp.dto.MeetingRescheduleRequest;
 import com.github.wsustudygroupapp.dto.MeetingSessionRequest;
 import com.github.wsustudygroupapp.model.MeetingSession;
 import com.github.wsustudygroupapp.service.MeetingSessionService;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -29,7 +31,7 @@ public class MeetingSessionController {
 
     /** POST /meetings — schedule a new session for a study group (201 Created). */
     @PostMapping
-    public ResponseEntity<MeetingSession> scheduleSession(@RequestBody MeetingSessionRequest request,
+    public ResponseEntity<MeetingSession> scheduleSession(@Valid @RequestBody MeetingSessionRequest request,
                                                           @AuthenticationPrincipal UserDetails userDetails) {
         MeetingSession session = meetingSessionService.scheduleSession(userDetails.getUsername(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(session);
@@ -42,11 +44,22 @@ public class MeetingSessionController {
         return ResponseEntity.ok(sessions);
     }
 
-    /** GET /meetings/group/{groupId} — returns all sessions for a specific group (200 OK). */
+    /** GET /meetings/group/{groupId} — returns all sessions for a specific group (200 OK).
+     *  Caller must be a member of the group, otherwise 403. */
     @GetMapping("/group/{groupId}")
-    public ResponseEntity<List<MeetingSession>> getSessionsForGroup(@PathVariable Long groupId) {
-        List<MeetingSession> sessions = meetingSessionService.getSessionsForGroup(groupId);
+    public ResponseEntity<List<MeetingSession>> getSessionsForGroup(@PathVariable Long groupId,
+                                                                    @AuthenticationPrincipal UserDetails userDetails) {
+        List<MeetingSession> sessions = meetingSessionService.getSessionsForGroup(groupId, userDetails.getUsername());
         return ResponseEntity.ok(sessions);
+    }
+
+    /** PATCH /meetings/{sessionId} — reschedule an upcoming session (only the creator, 200 OK). */
+    @PatchMapping("/{sessionId}")
+    public ResponseEntity<MeetingSession> rescheduleSession(@PathVariable Long sessionId,
+                                                            @Valid @RequestBody MeetingRescheduleRequest request,
+                                                            @AuthenticationPrincipal UserDetails userDetails) {
+        MeetingSession session = meetingSessionService.rescheduleSession(sessionId, userDetails.getUsername(), request);
+        return ResponseEntity.ok(session);
     }
 
     /** DELETE /meetings/{sessionId} — cancel a session (only the creator can do this, 204 No Content). */

--- a/src/main/java/com/github/wsustudygroupapp/dto/MeetingRescheduleRequest.java
+++ b/src/main/java/com/github/wsustudygroupapp/dto/MeetingRescheduleRequest.java
@@ -1,0 +1,39 @@
+package com.github.wsustudygroupapp.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * Request body for PATCH /meetings/{id}.
+ * Used by a session creator to reschedule or edit details. All fields are optional —
+ * a null field on a PATCH means "leave the existing value alone."
+ */
+@Data
+@Schema(description = "Meeting session reschedule/edit request")
+public class MeetingRescheduleRequest {
+
+    @Schema(description = "New date and time for the session (null = leave unchanged, edit details only)",
+            example = "2026-04-22T15:30:00")
+    @Future(message = "scheduledAt must be in the future")
+    private LocalDateTime scheduledAt;
+
+    @Schema(description = "Updated duration in minutes (null = leave unchanged, range 1–480)",
+            example = "90")
+    @Min(value = 1,   message = "durationMinutes must be at least 1")
+    @Max(value = 480, message = "durationMinutes must be 480 or less (8 hours)")
+    private Integer durationMinutes;
+
+    @Schema(description = "Updated location (optional)", example = "Bates Hall Rm 110")
+    @Size(max = 200, message = "location must be 200 characters or fewer")
+    private String location;
+
+    @Schema(description = "Updated notes/agenda (optional)", example = "Moved to a quieter room")
+    @Size(max = 2000, message = "notes must be 2000 characters or fewer")
+    private String notes;
+}

--- a/src/main/java/com/github/wsustudygroupapp/dto/MeetingSessionRequest.java
+++ b/src/main/java/com/github/wsustudygroupapp/dto/MeetingSessionRequest.java
@@ -1,6 +1,11 @@
 package com.github.wsustudygroupapp.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -15,14 +20,27 @@ import java.time.LocalDateTime;
 public class MeetingSessionRequest {
 
     @Schema(description = "ID of the study group this session belongs to", example = "2")
+    @NotNull(message = "groupId is required")
     private Long groupId;
 
-    @Schema(description = "Date and time the session starts", example = "2026-04-15T14:00:00")
+    @Schema(description = "Date and time the session starts (must be in the future)",
+            example = "2026-04-15T14:00:00")
+    @NotNull(message = "scheduledAt is required")
+    @Future(message = "scheduledAt must be in the future")
     private LocalDateTime scheduledAt;
 
+    @Schema(description = "Expected length of the session in minutes (optional, 1–480)",
+            example = "60")
+    @Min(value = 1,   message = "durationMinutes must be at least 1")
+    @Max(value = 480, message = "durationMinutes must be 480 or less (8 hours)")
+    private Integer durationMinutes;
+
     @Schema(description = "Where the session will take place", example = "Ely Library Rm 204")
+    @Size(max = 200, message = "location must be 200 characters or fewer")
     private String location;
 
-    @Schema(description = "Optional agenda or notes for the session", example = "Reviewing chapters 5 and 6 for the midterm")
+    @Schema(description = "Optional agenda or notes for the session",
+            example = "Reviewing chapters 5 and 6 for the midterm")
+    @Size(max = 2000, message = "notes must be 2000 characters or fewer")
     private String notes;
 }

--- a/src/main/java/com/github/wsustudygroupapp/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/github/wsustudygroupapp/exception/GlobalExceptionHandler.java
@@ -1,21 +1,94 @@
 package com.github.wsustudygroupapp.exception;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
 
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
+/**
+ * Returns a JSON error body for any exception thrown by a controller. The body always contains
+ * <ul>
+ *   <li>{@code message} — human-readable error text (kept stable for existing clients)</li>
+ *   <li>{@code code} — short machine-readable category, e.g. {@code VALIDATION}, {@code NOT_FOUND}</li>
+ *   <li>{@code reference} — short ID that is also written to the server log so support can
+ *       correlate a user-reported error with a stack trace</li>
+ *   <li>{@code status} — HTTP status as an int</li>
+ *   <li>{@code timestamp} — ISO-8601 instant the error was produced</li>
+ * </ul>
+ */
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    // Catches every RuntimeException thrown by service methods and returns the message
-    // as a readable JSON body instead of Spring's default 500 stack trace.
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    /** ResourceNotFoundException → 404 with structured body. */
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<Map<String, Object>> handleNotFound(ResourceNotFoundException ex) {
+        return build(HttpStatus.NOT_FOUND, "NOT_FOUND", ex.getMessage(), ex);
+    }
+
+    /** IllegalArgumentException → 400 (typical "validation"/business-rule failure). */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, Object>> handleIllegalArgument(IllegalArgumentException ex) {
+        return build(HttpStatus.BAD_REQUEST, "VALIDATION", ex.getMessage(), ex);
+    }
+
+    /** Bean-validation failures (@Valid on a controller param) → 400 with all field errors. */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidation(MethodArgumentNotValidException ex) {
+        List<String> details = ex.getBindingResult().getFieldErrors().stream()
+                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                .collect(Collectors.toList());
+        String message = details.isEmpty() ? "Validation failed" : String.join("; ", details);
+        return build(HttpStatus.BAD_REQUEST, "VALIDATION", message, ex);
+    }
+
+    /**
+     * Honors the status carried by a {@link ResponseStatusException} (e.g. 403 stays 403).
+     * Without this handler, the catch-all RuntimeException handler would coerce every status to 400.
+     */
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<Map<String, Object>> handleResponseStatus(ResponseStatusException ex) {
+        HttpStatusCode status = ex.getStatusCode();
+        HttpStatus resolved = HttpStatus.resolve(status.value());
+        if (resolved == null) resolved = HttpStatus.INTERNAL_SERVER_ERROR;
+        String code = resolved.name();
+        String message = ex.getReason() != null ? ex.getReason() : resolved.getReasonPhrase();
+        return build(resolved, code, message, ex);
+    }
+
+    /**
+     * Catches every other RuntimeException and returns 400 with the message — kept for
+     * backwards compatibility with existing controllers that throw plain RuntimeExceptions.
+     * Prefer throwing a more specific exception when possible.
+     */
     @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<Map<String, String>> handleRuntimeException(RuntimeException ex) {
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(Map.of("message", ex.getMessage()));
+    public ResponseEntity<Map<String, Object>> handleRuntimeException(RuntimeException ex) {
+        return build(HttpStatus.BAD_REQUEST, "ERROR", ex.getMessage(), ex);
+    }
+
+    private ResponseEntity<Map<String, Object>> build(HttpStatus status, String code, String message, Throwable ex) {
+        String reference = "REF-" + UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+        log.warn("[{}] {} ({}): {}", reference, code, status.value(), message, ex);
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("message",   message);
+        body.put("code",      code);
+        body.put("reference", reference);
+        body.put("status",    status.value());
+        body.put("timestamp", Instant.now().toString());
+        return ResponseEntity.status(status).body(body);
     }
 }

--- a/src/main/java/com/github/wsustudygroupapp/model/MeetingSession.java
+++ b/src/main/java/com/github/wsustudygroupapp/model/MeetingSession.java
@@ -40,6 +40,10 @@ public class MeetingSession {
     @Column(nullable = false)
     private LocalDateTime scheduledAt;
 
+    /** How long the session is expected to run, in minutes. Optional — null = unspecified. */
+    @Column
+    private Integer durationMinutes;
+
     /** Where the session will take place (e.g. "Ely Library Rm 204" or "Zoom"). */
     @Column
     private String location;

--- a/src/main/java/com/github/wsustudygroupapp/model/Notification.java
+++ b/src/main/java/com/github/wsustudygroupapp/model/Notification.java
@@ -23,6 +23,10 @@ public class Notification {
 
     public enum NotificationType {
         SESSION_SCHEDULED,
+        /** An existing session was moved to a different time by its creator. */
+        SESSION_RESCHEDULED,
+        /** A scheduled session was cancelled by its creator. */
+        SESSION_CANCELLED,
         BADGE_EARNED,
         MEMBER_JOINED
     }

--- a/src/main/java/com/github/wsustudygroupapp/service/MeetingSessionService.java
+++ b/src/main/java/com/github/wsustudygroupapp/service/MeetingSessionService.java
@@ -1,5 +1,6 @@
 package com.github.wsustudygroupapp.service;
 
+import com.github.wsustudygroupapp.dto.MeetingRescheduleRequest;
 import com.github.wsustudygroupapp.dto.MeetingSessionRequest;
 import com.github.wsustudygroupapp.exception.ResourceNotFoundException;
 import com.github.wsustudygroupapp.model.MeetingSession;
@@ -11,7 +12,9 @@ import com.github.wsustudygroupapp.repository.MeetingSessionRepository;
 import com.github.wsustudygroupapp.repository.ProfileRepository;
 import com.github.wsustudygroupapp.repository.StudyGroupRepository;
 import com.github.wsustudygroupapp.repository.UserRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -41,22 +44,36 @@ public class MeetingSessionService {
         this.notificationService = notificationService;
     }
 
-    /** Creates a new meeting session for a group and notifies all other members. */
+    /**
+     * Creates a new meeting session for a group and notifies all other members.
+     * Enforces:
+     *   • the scheduler is a member of the group (otherwise 403)
+     *   • the requested time is in the future (defense in depth — DTO already has @Future)
+     */
     public MeetingSession scheduleSession(String schedulerEmail, MeetingSessionRequest request) {
         Profile scheduler = currentProfile(schedulerEmail);
         StudyGroup group = studyGroupRepository.findById(request.getGroupId())
                 .orElseThrow(() -> new ResourceNotFoundException("Study group not found: " + request.getGroupId()));
 
+        requireGroupMember(group, scheduler, "schedule meetings in");
+
+        if (request.getScheduledAt() == null || !request.getScheduledAt().isAfter(LocalDateTime.now())) {
+            throw new IllegalArgumentException("Session must be scheduled for a future time");
+        }
+
         MeetingSession session = new MeetingSession();
         session.setStudyGroup(group);
         session.setScheduledBy(scheduler);
         session.setScheduledAt(request.getScheduledAt());
+        session.setDurationMinutes(request.getDurationMinutes());
         session.setLocation(request.getLocation());
         session.setNotes(request.getNotes());
 
         MeetingSession savedSession = meetingSessionRepository.save(session);
 
-        String message = "New study session scheduled: " + request.getScheduledAt() + " at " + request.getLocation();
+        String message = "New study session scheduled for " + request.getScheduledAt()
+                + (request.getLocation() != null && !request.getLocation().isBlank()
+                        ? " at " + request.getLocation() : "");
         notificationService.notifyGroupMembers(group, message, Notification.NotificationType.SESSION_SCHEDULED,
                 savedSession.getId(), scheduler.getId());
 
@@ -70,12 +87,73 @@ public class MeetingSessionService {
                 profile.getId(), LocalDateTime.now());
     }
 
-    /** Returns all sessions for a specific group, ordered by scheduled time. Used on the group dashboard. */
-    public List<MeetingSession> getSessionsForGroup(Long groupId) {
+    /**
+     * Returns all sessions for a specific group, ordered by scheduled time.
+     * Only members of the group may view its sessions — otherwise 403.
+     */
+    public List<MeetingSession> getSessionsForGroup(Long groupId, String requestingEmail) {
+        Profile profile = currentProfile(requestingEmail);
+        StudyGroup group = studyGroupRepository.findById(groupId)
+                .orElseThrow(() -> new ResourceNotFoundException("Study group not found: " + groupId));
+        requireGroupMember(group, profile, "view meetings for");
         return meetingSessionRepository.findByStudyGroupIdOrderByScheduledAtAsc(groupId);
     }
 
-    /** Deletes a session. Only the student who originally scheduled it can cancel. */
+    /**
+     * Updates an existing session. Only the creator can edit, and only before the session
+     * has started. Behavior depends on which fields are populated in the request:
+     * <ul>
+     *   <li>{@code scheduledAt} non-null → reschedules to the new time (must be in the future)
+     *       and sends a {@code SESSION_RESCHEDULED} notification to other members.</li>
+     *   <li>{@code scheduledAt} null → leaves the time alone, treats this as a details-only
+     *       edit (location/notes/duration). No reschedule notification.</li>
+     * </ul>
+     * Any of {@code location}, {@code notes}, {@code durationMinutes} that are non-null are applied;
+     * null fields leave the existing value unchanged.
+     */
+    public MeetingSession rescheduleSession(Long sessionId, String requestingEmail, MeetingRescheduleRequest request) {
+        Profile requester = currentProfile(requestingEmail);
+        MeetingSession session = meetingSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new ResourceNotFoundException("Meeting session not found: " + sessionId));
+
+        if (!session.getScheduledBy().getId().equals(requester.getId())) {
+            throw new IllegalArgumentException("Only the session creator can edit it");
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        if (!session.getScheduledAt().isAfter(now)) {
+            throw new IllegalArgumentException("Cannot edit a session that has already started");
+        }
+
+        boolean rescheduling = request.getScheduledAt() != null;
+        LocalDateTime previous = session.getScheduledAt();
+
+        if (rescheduling) {
+            if (!request.getScheduledAt().isAfter(now)) {
+                throw new IllegalArgumentException("New scheduled time must be in the future");
+            }
+            session.setScheduledAt(request.getScheduledAt());
+        }
+        if (request.getLocation()        != null) session.setLocation(request.getLocation());
+        if (request.getNotes()           != null) session.setNotes(request.getNotes());
+        if (request.getDurationMinutes() != null) session.setDurationMinutes(request.getDurationMinutes());
+
+        MeetingSession saved = meetingSessionRepository.save(session);
+
+        if (rescheduling) {
+            String message = requester.getName() + " rescheduled a session for "
+                    + session.getStudyGroup().getName() + ": was " + previous + ", now " + request.getScheduledAt();
+            notificationService.notifyGroupMembers(session.getStudyGroup(), message,
+                    Notification.NotificationType.SESSION_RESCHEDULED, saved.getId(), requester.getId());
+        }
+
+        return saved;
+    }
+
+    /**
+     * Deletes a session. Only the student who originally scheduled it can cancel.
+     * Notifies all other group members so the meeting drops off their lists.
+     */
     public void cancelSession(Long sessionId, String requestingEmail) {
         Profile requester = currentProfile(requestingEmail);
         MeetingSession session = meetingSessionRepository.findById(sessionId)
@@ -85,7 +163,26 @@ public class MeetingSessionService {
             throw new IllegalArgumentException("Only the session creator can cancel it");
         }
 
+        StudyGroup group = session.getStudyGroup();
+        LocalDateTime when = session.getScheduledAt();
+        Long sessionIdSnapshot = session.getId();
+
         meetingSessionRepository.delete(session);
+
+        String message = requester.getName() + " cancelled the session for "
+                + group.getName() + " scheduled for " + when;
+        notificationService.notifyGroupMembers(group, message,
+                Notification.NotificationType.SESSION_CANCELLED, sessionIdSnapshot, requester.getId());
+    }
+
+    // throws 403 if the profile is not a member of the group
+    private void requireGroupMember(StudyGroup group, Profile profile, String actionPhrase) {
+        boolean isMember = group.getMembers() != null
+                && group.getMembers().stream().anyMatch(m -> m.getId().equals(profile.getId()));
+        if (!isMember) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                    "You must be a member of this group to " + actionPhrase + " it");
+        }
     }
 
     // resolves the logged-in user's Profile from their email — throws 404 if not found

--- a/src/test/java/com/github/wsustudygroupapp/controller/MeetingSessionControllerTest.java
+++ b/src/test/java/com/github/wsustudygroupapp/controller/MeetingSessionControllerTest.java
@@ -1,5 +1,6 @@
 package com.github.wsustudygroupapp.controller;
 
+import com.github.wsustudygroupapp.dto.MeetingRescheduleRequest;
 import com.github.wsustudygroupapp.dto.MeetingSessionRequest;
 import com.github.wsustudygroupapp.exception.ResourceNotFoundException;
 import com.github.wsustudygroupapp.model.MeetingSession;
@@ -13,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -28,22 +30,31 @@ class MeetingSessionControllerTest {
     @InjectMocks private MeetingSessionController meetingSessionController;
 
     private static final String EMAIL = "test@westfield.ma.edu";
+    private static final LocalDateTime FUTURE     = LocalDateTime.of(2030, 1, 1, 14, 0);
+    private static final LocalDateTime FAR_FUTURE = LocalDateTime.of(2030, 6, 1, 14, 0);
+
     private MeetingSession mockSession;
     private MeetingSessionRequest sessionRequest;
+    private MeetingRescheduleRequest rescheduleRequest;
 
     @BeforeEach
     void setUp() {
         mockSession = new MeetingSession();
         mockSession.setId(10L);
-        mockSession.setScheduledAt(LocalDateTime.of(2026, 5, 10, 14, 0));
+        mockSession.setScheduledAt(FUTURE);
+        mockSession.setDurationMinutes(60);
         mockSession.setLocation("Ely Library Rm 204");
         mockSession.setNotes("Review chapters 5-7");
 
         sessionRequest = new MeetingSessionRequest();
         sessionRequest.setGroupId(5L);
-        sessionRequest.setScheduledAt(LocalDateTime.of(2026, 5, 10, 14, 0));
+        sessionRequest.setScheduledAt(FUTURE);
+        sessionRequest.setDurationMinutes(60);
         sessionRequest.setLocation("Ely Library Rm 204");
         sessionRequest.setNotes("Review chapters 5-7");
+
+        rescheduleRequest = new MeetingRescheduleRequest();
+        rescheduleRequest.setScheduledAt(FAR_FUTURE);
     }
 
     // stubs userDetails.getUsername() — called per-test to avoid UnnecessaryStubbingException
@@ -65,12 +76,42 @@ class MeetingSessionControllerTest {
     }
 
     @Test
+    void scheduleSession_forwardsAuthenticatedEmailToService() {
+        mockAuth();
+        when(meetingSessionService.scheduleSession(EMAIL, sessionRequest)).thenReturn(mockSession);
+
+        meetingSessionController.scheduleSession(sessionRequest, userDetails);
+
+        verify(meetingSessionService).scheduleSession(EMAIL, sessionRequest);
+    }
+
+    @Test
     void scheduleSession_serviceThrowsNotFound_propagates() {
         mockAuth();
         when(meetingSessionService.scheduleSession(EMAIL, sessionRequest))
                 .thenThrow(new ResourceNotFoundException("Study group not found: 5"));
 
         assertThrows(ResourceNotFoundException.class,
+                () -> meetingSessionController.scheduleSession(sessionRequest, userDetails));
+    }
+
+    @Test
+    void scheduleSession_serviceThrowsForbidden_propagates() {
+        mockAuth();
+        when(meetingSessionService.scheduleSession(EMAIL, sessionRequest))
+                .thenThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Not a member"));
+
+        assertThrows(ResponseStatusException.class,
+                () -> meetingSessionController.scheduleSession(sessionRequest, userDetails));
+    }
+
+    @Test
+    void scheduleSession_serviceThrowsIllegalArgument_propagates() {
+        mockAuth();
+        when(meetingSessionService.scheduleSession(EMAIL, sessionRequest))
+                .thenThrow(new IllegalArgumentException("Session must be scheduled for a future time"));
+
+        assertThrows(IllegalArgumentException.class,
                 () -> meetingSessionController.scheduleSession(sessionRequest, userDetails));
     }
 
@@ -98,6 +139,16 @@ class MeetingSessionControllerTest {
         assertTrue(response.getBody().isEmpty());
     }
 
+    @Test
+    void getUpcomingSessions_forwardsAuthenticatedEmailToService() {
+        mockAuth();
+        when(meetingSessionService.getUpcomingSessions(EMAIL)).thenReturn(List.of());
+
+        meetingSessionController.getUpcomingSessions(userDetails);
+
+        verify(meetingSessionService).getUpcomingSessions(EMAIL);
+    }
+
     // ── GET /meetings/group/{groupId} ─────────────────────────────────────────
 
     @Test
@@ -122,7 +173,73 @@ class MeetingSessionControllerTest {
         assertTrue(response.getBody().isEmpty());
     }
 
-    // ── DELETE /meetings/{sessionId} ───────────────────────��──────────────────
+    @Test
+    void getSessionsForGroup_forwardsGroupIdAndEmailToService() {
+        mockAuth();
+        when(meetingSessionService.getSessionsForGroup(5L, EMAIL)).thenReturn(List.of());
+
+        meetingSessionController.getSessionsForGroup(5L, userDetails);
+
+        verify(meetingSessionService).getSessionsForGroup(5L, EMAIL);
+    }
+
+    @Test
+    void getSessionsForGroup_serviceThrowsForbidden_propagates() {
+        mockAuth();
+        when(meetingSessionService.getSessionsForGroup(5L, EMAIL))
+                .thenThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Not a member"));
+
+        assertThrows(ResponseStatusException.class,
+                () -> meetingSessionController.getSessionsForGroup(5L, userDetails));
+    }
+
+    // ── PATCH /meetings/{sessionId} ───────────────────────────────────────────
+
+    @Test
+    void rescheduleSession_returns200WithUpdatedSession() {
+        mockAuth();
+        when(meetingSessionService.rescheduleSession(10L, EMAIL, rescheduleRequest))
+                .thenReturn(mockSession);
+
+        ResponseEntity<MeetingSession> response =
+                meetingSessionController.rescheduleSession(10L, rescheduleRequest, userDetails);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(mockSession, response.getBody());
+    }
+
+    @Test
+    void rescheduleSession_forwardsIdEmailAndRequestToService() {
+        mockAuth();
+        when(meetingSessionService.rescheduleSession(10L, EMAIL, rescheduleRequest))
+                .thenReturn(mockSession);
+
+        meetingSessionController.rescheduleSession(10L, rescheduleRequest, userDetails);
+
+        verify(meetingSessionService).rescheduleSession(10L, EMAIL, rescheduleRequest);
+    }
+
+    @Test
+    void rescheduleSession_serviceThrowsNotFound_propagates() {
+        mockAuth();
+        when(meetingSessionService.rescheduleSession(10L, EMAIL, rescheduleRequest))
+                .thenThrow(new ResourceNotFoundException("Meeting session not found: 10"));
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> meetingSessionController.rescheduleSession(10L, rescheduleRequest, userDetails));
+    }
+
+    @Test
+    void rescheduleSession_serviceThrowsIllegalArgument_propagates() {
+        mockAuth();
+        when(meetingSessionService.rescheduleSession(10L, EMAIL, rescheduleRequest))
+                .thenThrow(new IllegalArgumentException("Only the session creator can edit it"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> meetingSessionController.rescheduleSession(10L, rescheduleRequest, userDetails));
+    }
+
+    // ── DELETE /meetings/{sessionId} ──────────────────────────────────────────
 
     @Test
     void cancelSession_returns204NoContent() {
@@ -132,6 +249,16 @@ class MeetingSessionControllerTest {
         ResponseEntity<Void> response = meetingSessionController.cancelSession(10L, userDetails);
 
         assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+    }
+
+    @Test
+    void cancelSession_forwardsIdAndEmailToService() {
+        mockAuth();
+        doNothing().when(meetingSessionService).cancelSession(10L, EMAIL);
+
+        meetingSessionController.cancelSession(10L, userDetails);
+
+        verify(meetingSessionService).cancelSession(10L, EMAIL);
     }
 
     @Test

--- a/src/test/java/com/github/wsustudygroupapp/controller/MeetingSessionControllerTest.java
+++ b/src/test/java/com/github/wsustudygroupapp/controller/MeetingSessionControllerTest.java
@@ -102,9 +102,10 @@ class MeetingSessionControllerTest {
 
     @Test
     void getSessionsForGroup_returns200WithSessionList() {
-        when(meetingSessionService.getSessionsForGroup(5L)).thenReturn(List.of(mockSession));
+        mockAuth();
+        when(meetingSessionService.getSessionsForGroup(5L, EMAIL)).thenReturn(List.of(mockSession));
 
-        ResponseEntity<List<MeetingSession>> response = meetingSessionController.getSessionsForGroup(5L);
+        ResponseEntity<List<MeetingSession>> response = meetingSessionController.getSessionsForGroup(5L, userDetails);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(1, response.getBody().size());
@@ -112,9 +113,10 @@ class MeetingSessionControllerTest {
 
     @Test
     void getSessionsForGroup_noSessions_returns200WithEmptyList() {
-        when(meetingSessionService.getSessionsForGroup(5L)).thenReturn(List.of());
+        mockAuth();
+        when(meetingSessionService.getSessionsForGroup(5L, EMAIL)).thenReturn(List.of());
 
-        ResponseEntity<List<MeetingSession>> response = meetingSessionController.getSessionsForGroup(5L);
+        ResponseEntity<List<MeetingSession>> response = meetingSessionController.getSessionsForGroup(5L, userDetails);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertTrue(response.getBody().isEmpty());

--- a/src/test/java/com/github/wsustudygroupapp/service/MeetingSessionServiceTest.java
+++ b/src/test/java/com/github/wsustudygroupapp/service/MeetingSessionServiceTest.java
@@ -1,8 +1,10 @@
 package com.github.wsustudygroupapp.service;
 
+import com.github.wsustudygroupapp.dto.MeetingRescheduleRequest;
 import com.github.wsustudygroupapp.dto.MeetingSessionRequest;
 import com.github.wsustudygroupapp.exception.ResourceNotFoundException;
 import com.github.wsustudygroupapp.model.MeetingSession;
+import com.github.wsustudygroupapp.model.Notification;
 import com.github.wsustudygroupapp.model.Profile;
 import com.github.wsustudygroupapp.model.StudyGroup;
 import com.github.wsustudygroupapp.model.User;
@@ -13,9 +15,12 @@ import com.github.wsustudygroupapp.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -23,6 +28,8 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,6 +44,12 @@ class MeetingSessionServiceTest {
 
     private static final String EMAIL = "test@westfield.ma.edu";
     private static final String UNKNOWN_EMAIL = "ghost@westfield.ma.edu";
+
+    // Static far-future timestamps so reschedule "must be in future" checks pass
+    // without depending on the wall-clock — tests stay deterministic year-over-year.
+    private static final LocalDateTime FUTURE      = LocalDateTime.of(2030, 1, 1, 14, 0);
+    private static final LocalDateTime FAR_FUTURE  = LocalDateTime.of(2030, 6, 1, 14, 0);
+    private static final LocalDateTime PAST        = LocalDateTime.of(2020, 1, 1, 14, 0);
 
     private User mockUser;
     private Profile mockProfile;
@@ -53,10 +66,12 @@ class MeetingSessionServiceTest {
 
         mockProfile = new Profile();
         mockProfile.setId(1L);
+        mockProfile.setName("Alex Rivera");
         mockProfile.setUser(mockUser);
 
         otherProfile = new Profile();
         otherProfile.setId(99L);
+        otherProfile.setName("Casey Other");
 
         mockGroup = new StudyGroup();
         mockGroup.setId(5L);
@@ -67,18 +82,20 @@ class MeetingSessionServiceTest {
         mockSession.setId(10L);
         mockSession.setStudyGroup(mockGroup);
         mockSession.setScheduledBy(mockProfile);
-        mockSession.setScheduledAt(LocalDateTime.of(2026, 5, 10, 14, 0));
+        mockSession.setScheduledAt(FUTURE);
+        mockSession.setDurationMinutes(60);
         mockSession.setLocation("Ely Library Rm 204");
         mockSession.setNotes("Review chapters 5-7");
 
         sessionRequest = new MeetingSessionRequest();
         sessionRequest.setGroupId(5L);
-        sessionRequest.setScheduledAt(LocalDateTime.of(2026, 5, 10, 14, 0));
+        sessionRequest.setScheduledAt(FUTURE);
+        sessionRequest.setDurationMinutes(60);
         sessionRequest.setLocation("Ely Library Rm 204");
         sessionRequest.setNotes("Review chapters 5-7");
     }
 
-    // stubs the currentProfile() helper used by most service methods
+    // stubs the currentProfile() helper used by every public method
     private void stubCurrentProfile() {
         when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(mockUser));
         when(profileRepository.findByUserId(1L)).thenReturn(Optional.of(mockProfile));
@@ -102,6 +119,52 @@ class MeetingSessionServiceTest {
     }
 
     @Test
+    void scheduleSession_userNotInGroup_throwsForbidden() {
+        stubCurrentProfile();
+        // group has only otherProfile — current user (id=1) is not a member
+        StudyGroup foreignGroup = new StudyGroup();
+        foreignGroup.setId(5L);
+        foreignGroup.setMembers(List.of(otherProfile));
+        when(studyGroupRepository.findById(5L)).thenReturn(Optional.of(foreignGroup));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> meetingSessionService.scheduleSession(EMAIL, sessionRequest));
+        assertEquals(HttpStatus.FORBIDDEN.value(), ex.getStatusCode().value());
+    }
+
+    @Test
+    void scheduleSession_userNotInGroup_doesNotPersistOrNotify() {
+        stubCurrentProfile();
+        StudyGroup foreignGroup = new StudyGroup();
+        foreignGroup.setId(5L);
+        foreignGroup.setMembers(List.of(otherProfile));
+        when(studyGroupRepository.findById(5L)).thenReturn(Optional.of(foreignGroup));
+
+        assertThrows(ResponseStatusException.class,
+                () -> meetingSessionService.scheduleSession(EMAIL, sessionRequest));
+        verify(meetingSessionRepository, never()).save(any());
+        verifyNoInteractions(notificationService);
+    }
+
+    @Test
+    void scheduleSession_nullScheduledAt_throwsIllegalArgumentException() {
+        stubCurrentProfile();
+        when(studyGroupRepository.findById(5L)).thenReturn(Optional.of(mockGroup));
+        sessionRequest.setScheduledAt(null);
+        assertThrows(IllegalArgumentException.class,
+                () -> meetingSessionService.scheduleSession(EMAIL, sessionRequest));
+    }
+
+    @Test
+    void scheduleSession_pastScheduledAt_throwsIllegalArgumentException() {
+        stubCurrentProfile();
+        when(studyGroupRepository.findById(5L)).thenReturn(Optional.of(mockGroup));
+        sessionRequest.setScheduledAt(PAST);
+        assertThrows(IllegalArgumentException.class,
+                () -> meetingSessionService.scheduleSession(EMAIL, sessionRequest));
+    }
+
+    @Test
     void scheduleSession_setsAllFieldsOnNewSession() {
         stubCurrentProfile();
         when(studyGroupRepository.findById(5L)).thenReturn(Optional.of(mockGroup));
@@ -111,7 +174,8 @@ class MeetingSessionServiceTest {
 
         assertEquals(mockGroup, result.getStudyGroup());
         assertEquals(mockProfile, result.getScheduledBy());
-        assertEquals(sessionRequest.getScheduledAt(), result.getScheduledAt());
+        assertEquals(FUTURE, result.getScheduledAt());
+        assertEquals(60, result.getDurationMinutes());
         assertEquals("Ely Library Rm 204", result.getLocation());
         assertEquals("Review chapters 5-7", result.getNotes());
     }
@@ -128,14 +192,47 @@ class MeetingSessionServiceTest {
     }
 
     @Test
-    void scheduleSession_notifiesGroupMembers() {
+    void scheduleSession_notifiesGroupMembersWithSessionScheduledType() {
         stubCurrentProfile();
         when(studyGroupRepository.findById(5L)).thenReturn(Optional.of(mockGroup));
         when(meetingSessionRepository.save(any(MeetingSession.class))).thenReturn(mockSession);
 
         meetingSessionService.scheduleSession(EMAIL, sessionRequest);
 
-        verify(notificationService, times(1)).notifyGroupMembers(eq(mockGroup), anyString(), any(), eq(10L), eq(1L));
+        verify(notificationService, times(1)).notifyGroupMembers(
+                eq(mockGroup), anyString(),
+                eq(Notification.NotificationType.SESSION_SCHEDULED),
+                eq(10L), eq(1L));
+    }
+
+    @Test
+    void scheduleSession_notificationMessageOmitsLocationWhenBlank() {
+        stubCurrentProfile();
+        when(studyGroupRepository.findById(5L)).thenReturn(Optional.of(mockGroup));
+        when(meetingSessionRepository.save(any(MeetingSession.class))).thenReturn(mockSession);
+        sessionRequest.setLocation("");
+
+        meetingSessionService.scheduleSession(EMAIL, sessionRequest);
+
+        ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(notificationService).notifyGroupMembers(
+                any(), messageCaptor.capture(), any(), any(), any());
+        assertFalse(messageCaptor.getValue().contains("at "),
+                "Blank location should not produce an 'at ' suffix in the notification");
+    }
+
+    @Test
+    void scheduleSession_notificationMessageIncludesLocationWhenProvided() {
+        stubCurrentProfile();
+        when(studyGroupRepository.findById(5L)).thenReturn(Optional.of(mockGroup));
+        when(meetingSessionRepository.save(any(MeetingSession.class))).thenReturn(mockSession);
+
+        meetingSessionService.scheduleSession(EMAIL, sessionRequest);
+
+        ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(notificationService).notifyGroupMembers(
+                any(), messageCaptor.capture(), any(), any(), any());
+        assertTrue(messageCaptor.getValue().contains("Ely Library Rm 204"));
     }
 
     // ── getUpcomingSessions ───────────────────────────────────────────────────
@@ -171,6 +268,34 @@ class MeetingSessionServiceTest {
     // ── getSessionsForGroup ───────────────────────────────────────────────────
 
     @Test
+    void getSessionsForGroup_userNotFound_throwsResourceNotFoundException() {
+        when(userRepository.findByEmail(UNKNOWN_EMAIL)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class,
+                () -> meetingSessionService.getSessionsForGroup(5L, UNKNOWN_EMAIL));
+    }
+
+    @Test
+    void getSessionsForGroup_groupNotFound_throwsResourceNotFoundException() {
+        stubCurrentProfile();
+        when(studyGroupRepository.findById(5L)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class,
+                () -> meetingSessionService.getSessionsForGroup(5L, EMAIL));
+    }
+
+    @Test
+    void getSessionsForGroup_userNotInGroup_throwsForbidden() {
+        stubCurrentProfile();
+        StudyGroup foreignGroup = new StudyGroup();
+        foreignGroup.setId(5L);
+        foreignGroup.setMembers(List.of(otherProfile));
+        when(studyGroupRepository.findById(5L)).thenReturn(Optional.of(foreignGroup));
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> meetingSessionService.getSessionsForGroup(5L, EMAIL));
+        assertEquals(HttpStatus.FORBIDDEN.value(), ex.getStatusCode().value());
+    }
+
+    @Test
     void getSessionsForGroup_returnsSessionsOrderedByTime() {
         stubCurrentProfile();
         when(studyGroupRepository.findById(5L)).thenReturn(Optional.of(mockGroup));
@@ -191,6 +316,169 @@ class MeetingSessionServiceTest {
                 .thenReturn(List.of());
 
         assertTrue(meetingSessionService.getSessionsForGroup(5L, EMAIL).isEmpty());
+    }
+
+    // ── rescheduleSession ─────────────────────────────────────────────────────
+
+    @Test
+    void rescheduleSession_userNotFound_throwsResourceNotFoundException() {
+        when(userRepository.findByEmail(UNKNOWN_EMAIL)).thenReturn(Optional.empty());
+        MeetingRescheduleRequest req = new MeetingRescheduleRequest();
+        req.setScheduledAt(FAR_FUTURE);
+        assertThrows(ResourceNotFoundException.class,
+                () -> meetingSessionService.rescheduleSession(10L, UNKNOWN_EMAIL, req));
+    }
+
+    @Test
+    void rescheduleSession_sessionNotFound_throwsResourceNotFoundException() {
+        stubCurrentProfile();
+        when(meetingSessionRepository.findById(10L)).thenReturn(Optional.empty());
+        MeetingRescheduleRequest req = new MeetingRescheduleRequest();
+        req.setScheduledAt(FAR_FUTURE);
+        assertThrows(ResourceNotFoundException.class,
+                () -> meetingSessionService.rescheduleSession(10L, EMAIL, req));
+    }
+
+    @Test
+    void rescheduleSession_notTheCreator_throwsIllegalArgumentException() {
+        stubCurrentProfile();
+        mockSession.setScheduledBy(otherProfile);
+        when(meetingSessionRepository.findById(10L)).thenReturn(Optional.of(mockSession));
+
+        MeetingRescheduleRequest req = new MeetingRescheduleRequest();
+        req.setScheduledAt(FAR_FUTURE);
+        assertThrows(IllegalArgumentException.class,
+                () -> meetingSessionService.rescheduleSession(10L, EMAIL, req));
+    }
+
+    @Test
+    void rescheduleSession_notTheCreator_doesNotSaveOrNotify() {
+        stubCurrentProfile();
+        mockSession.setScheduledBy(otherProfile);
+        when(meetingSessionRepository.findById(10L)).thenReturn(Optional.of(mockSession));
+
+        MeetingRescheduleRequest req = new MeetingRescheduleRequest();
+        req.setScheduledAt(FAR_FUTURE);
+        assertThrows(IllegalArgumentException.class,
+                () -> meetingSessionService.rescheduleSession(10L, EMAIL, req));
+        verify(meetingSessionRepository, never()).save(any());
+        verifyNoInteractions(notificationService);
+    }
+
+    @Test
+    void rescheduleSession_sessionAlreadyStarted_throwsIllegalArgumentException() {
+        stubCurrentProfile();
+        mockSession.setScheduledAt(PAST); // already-started session
+        when(meetingSessionRepository.findById(10L)).thenReturn(Optional.of(mockSession));
+
+        MeetingRescheduleRequest req = new MeetingRescheduleRequest();
+        req.setScheduledAt(FAR_FUTURE);
+        assertThrows(IllegalArgumentException.class,
+                () -> meetingSessionService.rescheduleSession(10L, EMAIL, req));
+    }
+
+    @Test
+    void rescheduleSession_newScheduledAtInPast_throwsIllegalArgumentException() {
+        stubCurrentProfile();
+        when(meetingSessionRepository.findById(10L)).thenReturn(Optional.of(mockSession));
+
+        MeetingRescheduleRequest req = new MeetingRescheduleRequest();
+        req.setScheduledAt(PAST);
+        assertThrows(IllegalArgumentException.class,
+                () -> meetingSessionService.rescheduleSession(10L, EMAIL, req));
+    }
+
+    @Test
+    void rescheduleSession_fullReschedule_updatesScheduledAt() {
+        stubCurrentProfile();
+        when(meetingSessionRepository.findById(10L)).thenReturn(Optional.of(mockSession));
+        when(meetingSessionRepository.save(any(MeetingSession.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        MeetingRescheduleRequest req = new MeetingRescheduleRequest();
+        req.setScheduledAt(FAR_FUTURE);
+
+        MeetingSession result = meetingSessionService.rescheduleSession(10L, EMAIL, req);
+
+        assertEquals(FAR_FUTURE, result.getScheduledAt());
+    }
+
+    @Test
+    void rescheduleSession_fullReschedule_sendsRescheduledNotification() {
+        stubCurrentProfile();
+        when(meetingSessionRepository.findById(10L)).thenReturn(Optional.of(mockSession));
+        when(meetingSessionRepository.save(any(MeetingSession.class))).thenReturn(mockSession);
+
+        MeetingRescheduleRequest req = new MeetingRescheduleRequest();
+        req.setScheduledAt(FAR_FUTURE);
+        meetingSessionService.rescheduleSession(10L, EMAIL, req);
+
+        verify(notificationService, times(1)).notifyGroupMembers(
+                eq(mockGroup), anyString(),
+                eq(Notification.NotificationType.SESSION_RESCHEDULED),
+                eq(10L), eq(1L));
+    }
+
+    @Test
+    void rescheduleSession_detailsOnlyEdit_doesNotChangeScheduledAt() {
+        stubCurrentProfile();
+        when(meetingSessionRepository.findById(10L)).thenReturn(Optional.of(mockSession));
+        when(meetingSessionRepository.save(any(MeetingSession.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        MeetingRescheduleRequest req = new MeetingRescheduleRequest();
+        req.setScheduledAt(null); // details-only edit
+        req.setLocation("Bates Hall Rm 110");
+        req.setNotes("Quieter spot");
+        req.setDurationMinutes(90);
+
+        MeetingSession result = meetingSessionService.rescheduleSession(10L, EMAIL, req);
+
+        assertEquals(FUTURE, result.getScheduledAt(), "Time must be untouched on details-only edit");
+        assertEquals("Bates Hall Rm 110", result.getLocation());
+        assertEquals("Quieter spot", result.getNotes());
+        assertEquals(90, result.getDurationMinutes());
+    }
+
+    @Test
+    void rescheduleSession_detailsOnlyEdit_doesNotNotify() {
+        stubCurrentProfile();
+        when(meetingSessionRepository.findById(10L)).thenReturn(Optional.of(mockSession));
+        when(meetingSessionRepository.save(any(MeetingSession.class))).thenReturn(mockSession);
+
+        MeetingRescheduleRequest req = new MeetingRescheduleRequest();
+        req.setLocation("Bates Hall Rm 110");
+
+        meetingSessionService.rescheduleSession(10L, EMAIL, req);
+
+        verifyNoInteractions(notificationService);
+    }
+
+    @Test
+    void rescheduleSession_nullFieldsLeaveExistingValuesUnchanged() {
+        stubCurrentProfile();
+        when(meetingSessionRepository.findById(10L)).thenReturn(Optional.of(mockSession));
+        when(meetingSessionRepository.save(any(MeetingSession.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        // empty request — nothing should change
+        MeetingRescheduleRequest req = new MeetingRescheduleRequest();
+        MeetingSession result = meetingSessionService.rescheduleSession(10L, EMAIL, req);
+
+        assertEquals(FUTURE, result.getScheduledAt());
+        assertEquals(60, result.getDurationMinutes());
+        assertEquals("Ely Library Rm 204", result.getLocation());
+        assertEquals("Review chapters 5-7", result.getNotes());
+    }
+
+    @Test
+    void rescheduleSession_persistsExactlyOnce() {
+        stubCurrentProfile();
+        when(meetingSessionRepository.findById(10L)).thenReturn(Optional.of(mockSession));
+        when(meetingSessionRepository.save(any(MeetingSession.class))).thenReturn(mockSession);
+
+        MeetingRescheduleRequest req = new MeetingRescheduleRequest();
+        req.setScheduledAt(FAR_FUTURE);
+        meetingSessionService.rescheduleSession(10L, EMAIL, req);
+
+        verify(meetingSessionRepository, times(1)).save(any(MeetingSession.class));
     }
 
     // ── cancelSession ─────────────────────────────────────────────────────────
@@ -221,7 +509,7 @@ class MeetingSessionServiceTest {
     }
 
     @Test
-    void cancelSession_notTheCreator_doesNotDelete() {
+    void cancelSession_notTheCreator_doesNotDeleteOrNotify() {
         stubCurrentProfile();
         mockSession.setScheduledBy(otherProfile);
         when(meetingSessionRepository.findById(10L)).thenReturn(Optional.of(mockSession));
@@ -229,6 +517,7 @@ class MeetingSessionServiceTest {
         assertThrows(IllegalArgumentException.class,
                 () -> meetingSessionService.cancelSession(10L, EMAIL));
         verify(meetingSessionRepository, never()).delete(any());
+        verifyNoInteractions(notificationService);
     }
 
     @Test
@@ -239,5 +528,18 @@ class MeetingSessionServiceTest {
         meetingSessionService.cancelSession(10L, EMAIL);
 
         verify(meetingSessionRepository, times(1)).delete(mockSession);
+    }
+
+    @Test
+    void cancelSession_ownSession_sendsCancelledNotificationWithSnapshottedId() {
+        stubCurrentProfile();
+        when(meetingSessionRepository.findById(10L)).thenReturn(Optional.of(mockSession));
+
+        meetingSessionService.cancelSession(10L, EMAIL);
+
+        verify(notificationService, times(1)).notifyGroupMembers(
+                eq(mockGroup), anyString(),
+                eq(Notification.NotificationType.SESSION_CANCELLED),
+                eq(10L), eq(1L));
     }
 }

--- a/src/test/java/com/github/wsustudygroupapp/service/MeetingSessionServiceTest.java
+++ b/src/test/java/com/github/wsustudygroupapp/service/MeetingSessionServiceTest.java
@@ -172,10 +172,12 @@ class MeetingSessionServiceTest {
 
     @Test
     void getSessionsForGroup_returnsSessionsOrderedByTime() {
+        stubCurrentProfile();
+        when(studyGroupRepository.findById(5L)).thenReturn(Optional.of(mockGroup));
         when(meetingSessionRepository.findByStudyGroupIdOrderByScheduledAtAsc(5L))
                 .thenReturn(List.of(mockSession));
 
-        List<MeetingSession> result = meetingSessionService.getSessionsForGroup(5L);
+        List<MeetingSession> result = meetingSessionService.getSessionsForGroup(5L, EMAIL);
 
         assertEquals(1, result.size());
         assertEquals(mockSession, result.get(0));
@@ -183,10 +185,12 @@ class MeetingSessionServiceTest {
 
     @Test
     void getSessionsForGroup_noSessions_returnsEmptyList() {
+        stubCurrentProfile();
+        when(studyGroupRepository.findById(5L)).thenReturn(Optional.of(mockGroup));
         when(meetingSessionRepository.findByStudyGroupIdOrderByScheduledAtAsc(5L))
                 .thenReturn(List.of());
 
-        assertTrue(meetingSessionService.getSessionsForGroup(5L).isEmpty());
+        assertTrue(meetingSessionService.getSessionsForGroup(5L, EMAIL).isEmpty());
     }
 
     // ── cancelSession ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Builds out the meeting scheduler so it works end-to-end against the '/meetings'  API instead of the placeholder localStorage flow, adds reschedule + edit-details + cancel meetings with notifications, hardens the backend against the security gaps that were there (non-members could schedule into/read any group), and fully rewrites the unit tests.

## Changes
**Backend - meeting flows**
- New 'PATCH /meetings/{id}' endpoint backed by 'rescheduleSession'. Supports full reschedule (notifies the group with 'SESSION_RESCHEDULED') and details-only edits (no notification, time unchanged)
- 'CancelSession' now sends a 'SESSION_CANCELLED' notification to remaining members before deleting.
- New nullable 'durationMinutes' column on 'MeetingSession' so the UI can render start-end ranges.
- Added 'MeetingRescheduleRequest' DTO.

**Backend - security & validation**
- Membership check on 'scheduleSession' and 'getSessionsForGroup' (non-members get 403. This closes the anyone can schedule into/read any group's meetings issue. 
- 'scheduleSession' now also rejects past timestamps server-side.
- Bean validation on both DTOs. '@NotNull', '@Future', "@Min(1)/@Max(480)' on duration, '@Size' cap on location/notes. '@Valid' wired to the controller.
- 'GlobalExceptionHandler' returns a structured body ('message' + 'code' + 'reference' + 'status' + 'timestamp'). The reference ID is also written to the server log so support can correlate a user-reported error with a stack trace.
- New handlers for 'ResponseStatusException' (so 403 stays 403 instead of being coerced to 400) and 'MethodArgumentNotValidException' (so '@Valid' failures surface as a single readable field-level message).
- Added 'PATCH' to the CORS allowed methods (was blocking the reschedule preflight).
- Added 'SESSION_RESCHEDULED' and 'SESSION_CANCELLED' notification types for the bell UI to differentiate.

**Frontend**
- New 'MeetingsContext' wrapping the '/meetings' REST API with optimistic cache updates.
- New `MeetingScheduleModal` with three modes — create, reschedule (time-only), edit details (duration / location / notes only)
-  New `/meetings` page listing upcoming sessions across every group, grouped Today / Tomorrow / This Week / Later, with Edit details / Reschedule / Cancel actions for the creator
- "Meetings" link added to the desktop and mobile nav
- Errors surface the structured `code` + `reference` from the backend so the user can copy a support reference if something goes wrong
- Sends local-time strings (not UTC) to match the backend's `LocalDateTime` column — fixes the wall-clock-shift bug from the first pass

**Tests**
- Full rewrite of `MeetingSessionServiceTest` (30 tests) — every branch of every public method, including non-member 403, past-date rejection, full reschedule, details-only edit, cancel-with-notification, and the no-side-effects-on-rejection paths
- Full rewrite of `MeetingSessionControllerTest` — all 5 endpoints, status codes, parameter forwarding, and exception propagation

## Testing

- [x] Existing tests pass (`./mvnw test`)
- [x] Added tests for new behavior
- [x] Manually tested locally 

## Notes for Reviewer

- **For Brian (notifications):** there are now three meeting-related `NotificationType` values — `SESSION_SCHEDULED`, `SESSION_RESCHEDULED`, `SESSION_CANCELLED`. The records get written to `notification_table` correctly today; styling them differently in the bell dropdown is your call.
- **Schema migration:** Hibernate `ddl-auto=update` will add the `duration_minutes` column on first startup. Existing rows get `NULL` and just won't show a duration line — they aren't broken.
- **Old localStorage events feature is intentionally untouched** — `EventsContext`, `ScheduleEventModal`, and the Events tab in `MembersSidebar` keep working as the UI team built them. This PR adds a parallel real-backend path under `/meetings` rather than replacing the existing UI work.
- **Known limitation:** all timestamps are timezone-naive (`LocalDateTime`). Works correctly when the user and server share a timezone; in a multi-region deployment we'd need to migrate to `Instant` / `ZonedDateTime`. Out of scope here, worth flagging for a future ticket.
- **CORS change** in `SecurityConfig` (`PATCH` added to allowed methods) is the fix for an issue where the reschedule preflight was being blocked silently and surfacing as a generic "Network error" with no body. Worth knowing because it's a global config touch, but it's purely additive.