### PR TITLE
fix: correct leaderboard label to 'Create a study group'

### DIFF
--- a/frontend/src/pages/Leaderboard.jsx
+++ b/frontend/src/pages/Leaderboard.jsx
@@ -21,7 +21,7 @@ const MEDALS = ['🥇', '🥈', '🥉']
 const HOW_TO_EARN = [
   { icon: '👥', action: 'Join a study group',      pts: '+10 pts' },
   { icon: '💬', action: 'Send messages in chat',   pts: '+1 pt each' },
-  { icon: '⭐', action: 'Help a classmate',         pts: '+15 pts' },
+  { icon: '⭐', action: 'Create study group',         pts: '+15 pts' },
   { icon: '📅', action: 'Attend a study session',  pts: '+25 pts' },
   { icon: '🔥', action: 'Daily login streak',      pts: '+5 pts/day' },
 ]


### PR DESCRIPTION
## Summary
- Corrects the misleading 'Help a classmate' label in the How to Earn Points section to accurately reflect the actual backend trigger: creating a study group (+15 pts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)